### PR TITLE
getting rid of Text from Domain and Mailbox.

### DIFF
--- a/dnsext-types/DNS/StateBinary/SGet.hs
+++ b/dnsext-types/DNS/StateBinary/SGet.hs
@@ -20,7 +20,6 @@ module DNS.StateBinary.SGet (
   , getInt32
   , getNByteString
   , getNShortByteString
-  , getNText
   , sGetMany
   , getNBytes
   , getNOctets
@@ -42,7 +41,6 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as Short
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IM
-import qualified Data.Text.Encoding as T
 
 import DNS.StateBinary.Types
 import DNS.Types.Error
@@ -149,10 +147,6 @@ getNByteString n | n < 0     = overrun
 getNShortByteString :: Int -> SGet ShortByteString
 getNShortByteString n | n < 0     = overrun
                       | otherwise = ST.lift (Short.toShort <$> A.take n) <* addPosition n
-
-getNText :: Int -> SGet Text
-getNText n | n < 0     = overrun
-           | otherwise = ST.lift (T.decodeLatin1 <$> A.take n) <* addPosition n
 
 fitSGet :: Int -> SGet a -> SGet a
 fitSGet len parser | len < 0   = overrun

--- a/dnsext-types/DNS/StateBinary/SPut.hs
+++ b/dnsext-types/DNS/StateBinary/SPut.hs
@@ -15,8 +15,6 @@ module DNS.StateBinary.SPut (
   , putInt32
   , putShortByteString
   , putLenShortByteString
-  , putText
-  , putLenText
   , putReplicate
   -- ** Builder state
   , BState
@@ -40,8 +38,6 @@ import qualified Data.ByteString.Short as Short
 import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Semigroup as Sem
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 
 import DNS.StateBinary.Types
 import DNS.Types.Imports
@@ -89,15 +85,6 @@ putInt32 = fixedSized 4 (BB.int32BE . fromIntegral)
 
 putShortByteString :: ShortByteString -> SPut
 putShortByteString = writeSized Short.length BB.shortByteString
-
-putText :: Text -> SPut
-putText = writeSized T.length T.encodeUtf8Builder
-
--- In the case of the TXT record, we need to put the string length
-putLenText :: Text -> SPut
-putLenText txt = putInt8 len <> putText txt
-   where
-     len = fromIntegral $ T.length txt
 
 -- In the case of the TXT record, we need to put the string length
 putLenShortByteString :: ShortByteString -> SPut

--- a/dnsext-types/DNS/StateBinary/Types.hs
+++ b/dnsext-types/DNS/StateBinary/Types.hs
@@ -1,5 +1,5 @@
 module DNS.StateBinary.Types where
 
-import Data.Text
+import Data.ByteString.Short
 
-type RawDomain = Text
+type RawDomain = ShortByteString

--- a/dnsext-types/DNS/Types.hs
+++ b/dnsext-types/DNS/Types.hs
@@ -140,16 +140,16 @@ module DNS.Types (
   -- * Basic types
   -- ** Domain
   , Domain
+  , domainToShortByteString
+  , shortByteStringToDomain
   , domainToByteString
   , byteStringToDomain
-  , domainToText
-  , textToDomain
   -- ** Mailbox
   , Mailbox
+  , mailboxToShortByteString
+  , shortByteStringToMailbox
   , mailboxToByteString
   , byteStringToMailbox
-  , mailboxToText
-  , textToMailbox
   -- ** Opaque
   , Opaque
   , opaqueToByteString

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -33,7 +33,6 @@ import qualified DNS.Types.Parser as P
 
 -- $setup
 -- >>> :set -XOverloadedStrings
--- >>> import Data.Text
 
 -- | This type holds the /presentation form/ of fully-qualified DNS domain
 -- names encoded as ASCII A-labels, with \'.\' separators between labels.

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -335,6 +335,14 @@ labelEnd sep acc =
 -- Note: the separator is required to be either \'.\' or \'\@\', but this
 -- constraint is the caller's responsibility and is not checked here.
 --
+-- >>> unparseLabel _period "foo"
+-- "foo"
+-- >>> unparseLabel _period "foo.bar"
+-- "foo\\.bar"
+-- >>> unparseLabel _period "\x0aoo"
+-- "\\010oo"
+-- >>> unparseLabel _period "f\x7fo"
+-- "f\\127o"
 unparseLabel :: Word8 -> ShortByteString -> ShortByteString
 unparseLabel sep label
   | isAllPlain label = label

--- a/dnsext-types/DNS/Types/Imports.hs
+++ b/dnsext-types/DNS/Types/Imports.hs
@@ -1,7 +1,6 @@
 module DNS.Types.Imports (
     ByteString
   , ShortByteString
-  , Text
   , Int64
   , NonEmpty(..)
   , module Control.Applicative
@@ -35,7 +34,6 @@ import Data.List.NonEmpty (NonEmpty(..))
 import Data.Maybe
 import Data.Monoid
 import Data.Ord
-import Data.Text (Text)
 import Data.Typeable
 import Data.Word
 import Numeric

--- a/dnsext-types/DNS/Types/Message.hs
+++ b/dnsext-types/DNS/Types/Message.hs
@@ -128,7 +128,7 @@ putDNSMessage msg = putHeader hd
             fromEDNS :: AdditionalRecords -> Word16 -> EDNS -> AdditionalRecords
             fromEDNS rrs rc' edns = ResourceRecord name' type' class' ttl' rdata' : rrs
               where
-                name'  = textToDomain "."
+                name'  = shortByteStringToDomain "."
                 type'  = OPT
                 class' = maxUdpSize `min` (minUdpSize `max` ednsUdpSize edns)
                 ttl0'  = fromIntegral (rc' .&. 0xff0) `shiftL` 20

--- a/dnsext-types/DNS/Types/Parser.hs
+++ b/dnsext-types/DNS/Types/Parser.hs
@@ -1,0 +1,34 @@
+module DNS.Types.Parser (
+    Parser
+  , Builder
+  , ToBuilder(..)
+  , parse
+  , char
+  , string
+  , eof
+  , option
+  , match
+  , skip
+  , skipSome
+  , satisfy
+  , digit
+  , anyChar
+  ) where
+
+import DNS.Types.Imports
+import DNS.Types.ShortBuilder
+import qualified DNS.Types.ShortParser as P
+import DNS.Types.ShortParser hiding (parse, char, string)
+
+parse :: Parser Builder
+      -> ShortByteString
+      -> (Maybe ShortByteString, ShortByteString)
+parse p bs0 = case P.parse p bs0 of
+  (Nothing, bs) -> (Nothing, bs)
+  (Just b,  bs) -> (Just (build b), bs)
+
+char :: Word8 -> Parser Builder
+char w = toBuilder <$> P.char w
+
+string :: ShortByteString -> Parser Builder
+string s = toBuilder <$> P.string s

--- a/dnsext-types/DNS/Types/Parser.hs
+++ b/dnsext-types/DNS/Types/Parser.hs
@@ -1,5 +1,6 @@
 module DNS.Types.Parser (
     Parser
+  , Result(..)
   , Builder
   , ToBuilder(..)
   , parse
@@ -18,14 +19,15 @@ module DNS.Types.Parser (
 import DNS.Types.Imports
 import DNS.Types.ShortBuilder
 import qualified DNS.Types.ShortParser as P
-import DNS.Types.ShortParser hiding (parse, char, string)
+import DNS.Types.ShortParser hiding (char, string)
 
 parse :: Parser Builder
       -> ShortByteString
       -> (Maybe ShortByteString, ShortByteString)
-parse p bs0 = case P.parse p bs0 of
-  (Nothing, bs) -> (Nothing, bs)
-  (Just b,  bs) -> (Just (build b), bs)
+parse p bs0 = case P.runParser p bs0 of
+  (Unmatch, bs) -> (Nothing, bs)
+  (Match b, bs) -> (Just (build b), bs)
+  (Fail _,  bs) -> (Nothing, bs)
 
 char :: Word8 -> Parser Builder
 char w = toBuilder <$> P.char w

--- a/dnsext-types/DNS/Types/ShortBuilder.hs
+++ b/dnsext-types/DNS/Types/ShortBuilder.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+module DNS.Types.ShortBuilder (
+    ToBuilder(..)
+  , Builder
+  , build
+  ) where
+
+import qualified Data.ByteString.Short as Short
+import Data.ByteString.Short.Internal (ShortByteString(..))
+import GHC.Exts (Int(..), ByteArray#, MutableByteArray#, unsafeFreezeByteArray#, newByteArray#, writeWord8Array#, copyByteArray#)
+import GHC.ST (ST(ST), runST)
+import GHC.Word
+
+import DNS.Types.Imports
+
+data Piece = PWord8 Word8 | PShort ShortByteString
+
+class ToBuilder a where
+    toBuilder :: a -> Builder
+
+instance ToBuilder Word8 where
+    toBuilder w8 = Builder 1 ([PWord8 w8] ++)
+
+instance ToBuilder ShortByteString where
+    toBuilder sbs = Builder (Short.length sbs) ([PShort sbs] ++)
+
+instance Semigroup Builder where
+    Builder l0 b0 <> Builder l1 b1 = Builder (l0 + l1) (b0 . b1)
+
+instance Monoid Builder where
+    mempty = Builder 0 id
+
+data Builder = Builder !Int ([Piece] -> [Piece])
+
+build :: Builder -> ShortByteString
+build (Builder len b) = create len $ \mba -> go mba 0 xs
+  where
+    xs = b []
+    go _ _ [] = return ()
+    go mba i (PWord8 w8 : cs) = do
+        writeWord8Array mba i w8
+        go mba (i+1) cs
+    go mba i (PShort src : cs) = do
+        let l = Short.length src
+        copyByteArray (asBA src) 0 mba i l
+        go mba (i+l) cs
+
+-- Stolen from Data.ByteString.Short.Internal, sigh.
+
+data BA    = BA# ByteArray#
+data MBA s = MBA# (MutableByteArray# s)
+
+create :: Int -> (forall s. MBA s -> ST s ()) -> ShortByteString
+create len fill =
+    runST (do
+      mba <- newByteArray len
+      fill mba
+      BA# ba# <- unsafeFreezeByteArray mba
+      return (SBS ba#))
+
+newByteArray :: Int -> ST s (MBA s)
+newByteArray (I# len#) =
+    ST $ \s0 -> case newByteArray# len# s0 of
+                 (# s, mba# #) -> (# s, MBA# mba# #)
+
+unsafeFreezeByteArray :: MBA s -> ST s BA
+unsafeFreezeByteArray (MBA# mba#) =
+    ST $ \s0 -> case unsafeFreezeByteArray# mba# s0 of
+                 (# s, ba# #) -> (# s, BA# ba# #)
+
+writeWord8Array :: MBA s -> Int -> Word8 -> ST s ()
+writeWord8Array (MBA# mba#) (I# i#) (W8# w#) =
+  ST $ \s0 -> case writeWord8Array# mba# i# w# s0 of
+               s -> (# s, () #)
+
+copyByteArray :: BA -> Int -> MBA s -> Int -> Int -> ST s ()
+copyByteArray (BA# src#) (I# src_off#) (MBA# dst#) (I# dst_off#) (I# len#) =
+    ST $ \s0 -> case copyByteArray# src# src_off# dst# dst_off# len# s0 of
+                 s -> (# s, () #)
+
+asBA :: ShortByteString -> BA
+asBA (SBS ba#) = BA# ba#

--- a/dnsext-types/DNS/Types/ShortParser.hs
+++ b/dnsext-types/DNS/Types/ShortParser.hs
@@ -1,0 +1,185 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module DNS.Types.ShortParser where
+
+import Control.Applicative
+import Control.Monad
+import Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Short as Short
+import Data.Word
+import Data.Word8
+
+----------------------------------------------------------------
+
+data Parser a = Parser {
+  -- | Getting the internal parser.
+    runParser :: ShortByteString -> (Maybe a, ShortByteString)
+  }
+
+----------------------------------------------------------------
+
+instance Functor Parser where
+    f `fmap` p = return f <*> p
+
+instance Applicative Parser where
+    pure a = Parser $ \bs -> (Just a, bs)
+    (<*>)  = ap
+
+instance Monad Parser where
+    return   = pure
+    p >>= f  = Parser $ \bs -> case runParser p bs of
+        (Nothing, bs') -> (Nothing, bs')
+        (Just a,  bs') -> runParser (f a) bs'
+
+instance MonadFail Parser where
+    fail _   = Parser $ \bs -> (Nothing, bs)
+
+instance MonadPlus Parser where
+    mzero       = Parser $ \bs -> (Nothing, bs)
+    p `mplus` q = Parser $ \bs -> case runParser p bs of
+        (Nothing, _)   -> runParser q bs
+        (Just a,  bs') -> (Just a, bs')
+
+instance Alternative Parser where
+    empty = mzero
+    (<|>) = mplus
+
+----------------------------------------------------------------
+
+-- | Run a parser.
+parse :: Parser a -> ShortByteString -> (Maybe a, ShortByteString)
+parse p bs = runParser p bs
+
+----------------------------------------------------------------
+-- | The parser @satisfy f@ succeeds for any character for which the
+--   supplied function @f@ returns 'True'. Returns the character that is
+--   actually parsed.
+satisfy :: (Word8 -> Bool) -> Parser Word8
+satisfy predicate = Parser sat
+  where
+    sat bs = case Short.uncons bs of
+      Nothing         -> (Nothing, "")
+      Just (b,bs')
+        | predicate b -> (Just b,  bs')
+        | otherwise   -> (Nothing, bs)
+
+eof :: Parser ()
+eof = Parser $ \bs -> if bs == "" then (Just (), "") else (Nothing, bs)
+
+----------------------------------------------------------------
+-- | The parser try p behaves like parser p, except that it pretends
+--   that it hasn't consumed any input when an error occurs.
+try :: Parser a -> Parser a
+try p = Parser $ \bs -> case runParser p bs of
+        (Nothing, _  ) -> (Nothing, bs)
+        (Just a,  bs') -> (Just a,  bs')
+
+----------------------------------------------------------------
+
+-- | @char c@ parses a single character @c@. Returns the parsed character.
+char :: Word8 -> Parser Word8
+char c = satisfy (c ==)
+
+skip :: (Word8 -> Bool) -> Parser ()
+skip = void . satisfy
+
+-- | @string s@ parses a sequence of characters given by @s@. Returns
+--   the parsed string
+
+{-
+string :: ShortByteString -> Parser ShortByteString
+string bs0 = Short.pack <$> loop bs0
+  where
+    loop bs = case Short.uncons bs of
+      Nothing      -> pure []
+      Just (b,bs') -> (:) <$> char b <*> loop bs'
+-}
+
+string :: ShortByteString -> Parser ShortByteString
+string bs0 = loop bs0 >> pure bs0
+ where
+     loop bs = case Short.uncons bs of
+       Nothing      -> pure ()
+       Just (b,bs') -> do
+           void $ char b
+           void $ string bs'
+
+----------------------------------------------------------------
+
+-- | This parser succeeds for any character. Returns the parsed character.
+anyChar :: Parser Word8
+anyChar = satisfy (const True)
+
+-- | @oneOf cs@ succeeds if the current character is in the supplied list of
+--   characters @cs@. Returns the parsed character.
+oneOf :: [Word8] -> Parser Word8
+oneOf cs = satisfy (`elem` cs)
+
+-- | As the dual of 'oneOf', @noneOf cs@ succeeds if the current
+--   character /not/ in the supplied list of characters @cs@. Returns the
+--   parsed character.
+noneOf :: [Word8] -> Parser Word8
+noneOf cs = satisfy (`notElem` cs)
+
+-- | Parses a letter or digit (a character between \'0\' and \'9\').
+--   Returns the parsed character.
+alphaNum :: Parser Word8
+alphaNum = satisfy isAlphaNum
+
+-- | Parses a digit. Returns the parsed character.
+digit :: Parser Word8
+digit = satisfy isDigit
+
+-- | Parses a hexadecimal digit (a digit or a letter between \'a\' and
+--   \'f\' or \'A\' and \'F\'). Returns the parsed character.
+hexDigit :: Parser Word8
+hexDigit = satisfy isHexDigit
+
+-- | Parses a white space character (any character which satisfies 'isSpace')
+--   Returns the parsed character.
+space :: Parser Word8
+space = satisfy isSpace
+
+----------------------------------------------------------------
+
+-- | @choice ps@ tries to apply the parsers in the list @ps@ in order,
+--   until one of them succeeds. Returns the value of the succeeding
+--   parser.
+choice :: [Parser a] -> Parser a
+choice = foldr (<|>) mzero
+
+-- | @option x p@ tries to apply parser @p@. If @p@ fails without
+--   consuming input, it returns the value @x@, otherwise the value
+--   returned by @p@.
+option :: a -> Parser a -> Parser a
+option x p = p <|> pure x
+
+-- | @skipMany p@ applies the parser @p@ /zero/ or more times, skipping
+--   its result.
+skipMany :: Parser a -> Parser ()
+skipMany p = void $ many p
+
+-- | @skipSome p@ applies the parser @p@ /one/ or more times, skipping
+--   its result.
+skipSome :: Parser a -> Parser ()
+skipSome p = void $ some p
+
+-- | @sepBy1 p sep@ parses /one/ or more occurrences of @p@, separated
+--   by @sep@. Returns a list of values returned by @p@.
+sepBy1 :: Parser a -> Parser b -> Parser [a]
+sepBy1 p sep = (:) <$> p <*> many (sep *> p)
+
+-- | @manyTill p end@ applies parser @p@ /zero/ or more times until
+--   parser @end@ succeeds. Returns the list of values returned by @p@.
+manyTill :: Parser a -> Parser b -> Parser [a]
+manyTill p end = scan
+  where
+    scan = [] <$ end <|> (:) <$> p <*> scan
+
+match :: Parser a -> Parser (ShortByteString, a)
+match p = Parser $ \bs -> case runParser p bs of
+  (Nothing, _  ) -> (Nothing, bs)
+  (Just a,  bs') -> let len  = Short.length bs
+                        len' = Short.length bs'
+                        bs'' = Short.take (len - len') bs
+                    in (Just (bs'', a),  bs')

--- a/dnsext-types/DNS/Types/ShortParser.hs
+++ b/dnsext-types/DNS/Types/ShortParser.hs
@@ -86,15 +86,6 @@ skip = void . satisfy
 -- | @string s@ parses a sequence of characters given by @s@. Returns
 --   the parsed string
 
-{-
-string :: ShortByteString -> Parser ShortByteString
-string bs0 = Short.pack <$> loop bs0
-  where
-    loop bs = case Short.uncons bs of
-      Nothing      -> pure []
-      Just (b,bs') -> (:) <$> char b <*> loop bs'
--}
-
 string :: ShortByteString -> Parser ShortByteString
 string bs0 = loop bs0 >> pure bs0
  where

--- a/dnsext-types/dnsext-types.cabal
+++ b/dnsext-types/dnsext-types.cabal
@@ -43,6 +43,7 @@ library
         DNS.Types.Opaque
         DNS.Types.RData
         DNS.Types.Sec
+        DNS.Types.ShortParser
         DNS.Types.Type
 
     default-language: Haskell2010
@@ -59,7 +60,6 @@ library
         hourglass,
         iproute >=1.3.2,
         mtl,
-        text,
         word8
 
 test-suite doctests
@@ -91,5 +91,4 @@ test-suite spec
         bytestring,
         hspec,
         iproute >=1.3.2,
-        text,
         word8

--- a/dnsext-types/dnsext-types.cabal
+++ b/dnsext-types/dnsext-types.cabal
@@ -41,8 +41,10 @@ library
         DNS.Types.Imports
         DNS.Types.Message
         DNS.Types.Opaque
+        DNS.Types.Parser
         DNS.Types.RData
         DNS.Types.Sec
+        DNS.Types.ShortBuilder
         DNS.Types.ShortParser
         DNS.Types.Type
 

--- a/dnsext-types/test/RoundTripSpec.hs
+++ b/dnsext-types/test/RoundTripSpec.hs
@@ -9,7 +9,6 @@ import qualified Data.ByteString.Char8 as C8
 import qualified Data.ByteString.Short as Short
 import qualified Data.IP
 import Data.IP (Addr, IP(..), IPv4, IPv6, toIPv4, toIPv6, makeAddrRange)
-import Data.Text (Text)
 import Data.Word
 import GHC.Exts (the, groupWith)
 import Test.Hspec
@@ -150,19 +149,17 @@ genIPv6 = toIPv6 <$> replicateM 8 (fromIntegral <$> genWord16)
 genOpaque :: Gen Opaque
 genOpaque = byteStringToOpaque <$> elements [ "", "a", "a.b", "abc", "a.b.c", "a\\.b.c", "\\001.a.b", "\\$.a.b" ]
 
-genByteString :: Gen Text
-genByteString = elements
-    [ "", "a", "a.b", "abc", "a.b.c", "a\\.b.c", "\\001.a.b", "\\$.a.b" ]
-
-genMboxString :: Gen Text
-genMboxString = elements
-    [ "", "a", "a@b", "abc", "a@b.c", "first.last@example.org" ]
-
 genDomain :: Gen Domain
-genDomain = textToDomain . (<> ".") <$>  genByteString
+genDomain = shortByteStringToDomain . (<> ".") <$>  genDomainString
+  where
+    genDomainString = elements
+        ["", "a", "a.b", "abc", "a.b.c", "a\\.b.c", "\\001.a.b", "\\$.a.b"]
 
 genMailbox :: Gen Mailbox
-genMailbox = textToMailbox . (<> ".") <$> genMboxString
+genMailbox = shortByteStringToMailbox . (<> ".") <$> genMboxString
+  where
+    genMboxString = elements
+        ["", "a", "a@b", "abc", "a@b.c", "first.last@example.org"]
 
 genDNSHeader :: Word16 -> Gen DNSHeader
 genDNSHeader maxrc = DNSHeader <$> genWord16 <*> genDNSFlags maxrc


### PR DESCRIPTION
`Text` is dangerous if 8bit parts are used. 
This PR gets rid of `Text` from `Domain` and `Mailbox`.
Since attoparsec does not support `ShortByteString`, `Parser` for `ShortByteString` is home-brewed.