### PR TITLE
SPut monad

### DIFF
--- a/dnsext-dnssec/DNS/SEC/Flags.hs
+++ b/dnsext-dnssec/DNS/SEC/Flags.hs
@@ -24,7 +24,7 @@ fromDNSKEYflags flags = foldl' (.|.) 0 $ map toW flags
     toW REVOKE           = 0b0000000010000000
     toW SecureEntryPoint = 0b0000000000000001
 
-putDNSKEYflags :: [DNSKEY_Flag] -> SPut
+putDNSKEYflags :: [DNSKEY_Flag] -> SPut ()
 putDNSKEYflags = put16 . fromDNSKEYflags
 
 getDNSKEYflags :: SGet [DNSKEY_Flag]
@@ -45,7 +45,7 @@ fromNSEC3flags flags = foldl' (.|.) 0 $ map toW flags
   where
     toW OptOut = 0b00000001
 
-putNSEC3flags :: [NSEC3_Flag] -> SPut
+putNSEC3flags :: [NSEC3_Flag] -> SPut ()
 putNSEC3flags = put8 . fromNSEC3flags
 
 getNSEC3flags :: SGet [NSEC3_Flag]

--- a/dnsext-dnssec/DNS/SEC/HashAlg.hs
+++ b/dnsext-dnssec/DNS/SEC/HashAlg.hs
@@ -34,7 +34,7 @@ instance Show DigestAlg where
     show SHA384        = "SHA384"
     show (DigestAlg n) = "DigestAlg " ++ show n
 
-putDigestAlg :: DigestAlg -> SPut
+putDigestAlg :: DigestAlg -> SPut ()
 putDigestAlg = put8 . fromDigestAlg
 
 getDigestAlg :: SGet DigestAlg
@@ -56,7 +56,7 @@ instance Show HashAlg where
     show Hash_SHA1   = "SHA1"
     show (HashAlg n) = "HashAlg " ++ show n
 
-putHashAlg :: HashAlg -> SPut
+putHashAlg :: HashAlg -> SPut ()
 putHashAlg = put8 . fromHashAlg
 
 getHashAlg :: SGet HashAlg

--- a/dnsext-dnssec/DNS/SEC/Opts.hs
+++ b/dnsext-dnssec/DNS/SEC/Opts.hs
@@ -86,9 +86,8 @@ _showAlgList :: Show a => String -> [a] -> String
 _showAlgList nm ws = nm ++ " " ++ intercalate "," (map show ws)
 
 -- | Encode EDNS OPTION consisting of a list of octets.
-putODWords :: Word16 -> [Word8] -> SPut
-putODWords code ws =
-     mconcat [ put16 code
-             , putInt16 $ length ws
-             , mconcat $ map put8 ws
-             ]
+putODWords :: Word16 -> [Word8] -> SPut ()
+putODWords code ws = do
+    put16 code
+    putInt16 $ length ws
+    mapM_ put8 ws

--- a/dnsext-dnssec/DNS/SEC/PubAlg.hs
+++ b/dnsext-dnssec/DNS/SEC/PubAlg.hs
@@ -85,7 +85,7 @@ instance Show PubAlg where
     show PRIVATEOID         = "PRIVATEOID"
     show (PubAlg n)        = "PubAlg " ++ show n
 
-putPubAlg :: PubAlg -> SPut
+putPubAlg :: PubAlg -> SPut ()
 putPubAlg = put8 . fromPubAlg
 
 getPubAlg :: SGet PubAlg

--- a/dnsext-dnssec/DNS/SEC/PubKey.hs
+++ b/dnsext-dnssec/DNS/SEC/PubKey.hs
@@ -63,7 +63,7 @@ fromPubKey (PubKey_RSA len e n)
 fromPubKey (PubKey_ECDSA x y) = x <> y
 fromPubKey (PubKey_Opaque o)    = o
 
-putPubKey :: PubKey -> SPut
+putPubKey :: PubKey -> SPut ()
 putPubKey pub = putOpaque $ fromPubKey pub
 
 getPubKey :: PubAlg -> Int -> SGet PubKey

--- a/dnsext-dnssec/DNS/SEC/Time.hs
+++ b/dnsext-dnssec/DNS/SEC/Time.hs
@@ -25,5 +25,5 @@ getDnsTime   = do
     tdns <- get32
     return $ dnsTime tdns tnow
 
-putDnsTime :: Int64 -> SPut
+putDnsTime :: Int64 -> SPut ()
 putDnsTime = put32 . fromIntegral

--- a/dnsext-types/DNS/StateBinary/SPut.hs
+++ b/dnsext-types/DNS/StateBinary/SPut.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 
 module DNS.StateBinary.SPut (
@@ -15,12 +14,15 @@ module DNS.StateBinary.SPut (
   , putShortByteString
   , putLenShortByteString
   , putReplicate
+  -- ** Lower utilities
+  , unexpectedSized
   -- ** Builder state
   , BState
   , builderPosition
   , addBuilderPosition
   , pushPointer
   , popPointer
+  , appendBuilder
   -- ** Re-exports (fixme)
   , State
   , ST.modify
@@ -30,13 +32,13 @@ module DNS.StateBinary.SPut (
 import Control.Monad.State.Strict (State)
 import qualified Control.Monad.State.Strict as ST
 import Data.ByteString.Builder (Builder)
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as BB
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.ByteString.Lazy.Char8 as LC8
 import qualified Data.ByteString.Short as Short
 import Data.Map (Map)
 import qualified Data.Map as M
-import Data.Semigroup as Sem
 
 import DNS.StateBinary.Types
 import DNS.Types.Imports
@@ -44,80 +46,101 @@ import DNS.Types.Imports
 ----------------------------------------------------------------
 
 -- | Builder type
-type SPut = State BState Builder
+type SPut a = State BState a
+
+runSPut :: SPut () -> ByteString
+runSPut sput = toBS $ bstBuilder $ run sput
+  where
+    run x = ST.execState x initialBState
+    toBS = LC8.toStrict . BB.toLazyByteString
+
+----------------------------------------------------------------
 
 -- | Builder state
 data BState = BState {
-    bstDomain :: Map RawDomain Int
+    bstDomain   :: Map RawDomain Int
   , bstPosition :: Int
+  , bstBuilder  :: Builder
 }
 
 initialBState :: BState
-initialBState = BState M.empty 0
+initialBState = BState M.empty 0 mempty
 
-instance Sem.Semigroup SPut where
-    p1 <> p2 = (Sem.<>) <$> p1 <*> p2
-
-instance Monoid SPut where
-    mempty = return mempty
-#if !(MIN_VERSION_base(4,11,0))
-    mappend = (Sem.<>)
-#endif
-
-put8 :: Word8 -> SPut
-put8 = fixedSized 1 BB.word8
-
-put16 :: Word16 -> SPut
-put16 = fixedSized 2 BB.word16BE
-
-put32 :: Word32 -> SPut
-put32 = fixedSized 4 BB.word32BE
-
-putInt8 :: Int -> SPut
-putInt8 = fixedSized 1 (BB.int8 . fromIntegral)
-
-putInt16 :: Int -> SPut
-putInt16 = fixedSized 2 (BB.int16BE . fromIntegral)
-
-putInt32 :: Int -> SPut
-putInt32 = fixedSized 4 (BB.int32BE . fromIntegral)
-
-putShortByteString :: ShortByteString -> SPut
-putShortByteString = writeSized Short.length BB.shortByteString
-
--- In the case of the TXT record, we need to put the string length
-putLenShortByteString :: ShortByteString -> SPut
-putLenShortByteString txt = putInt8 len <> putShortByteString txt
-   where
-     len = fromIntegral $ Short.length txt
-
-putReplicate :: Int -> Word8 -> SPut
-putReplicate n w =
-    fixedSized n BB.lazyByteString $ LB.replicate (fromIntegral n) w
-
-addBuilderPosition :: Int -> State BState ()
-addBuilderPosition n = do
-    BState m cur <- ST.get
-    ST.put $ BState m (cur+n)
-
-fixedSized :: Int -> (a -> Builder) -> a -> SPut
-fixedSized n f a = do addBuilderPosition n
-                      return (f a)
-
-writeSized :: (a -> Int) -> (a -> Builder) -> a -> SPut
-writeSized n f a = do addBuilderPosition (n a)
-                      return (f a)
+----------------------------------------------------------------
 
 builderPosition :: State BState Int
 builderPosition = ST.gets bstPosition
+
+addBuilderPosition :: Int -> State BState ()
+addBuilderPosition n = do
+    BState m cur b <- ST.get
+    ST.put $ BState m (cur+n) b
 
 popPointer :: RawDomain -> State BState (Maybe Int)
 popPointer dom = ST.gets (M.lookup dom . bstDomain)
 
 pushPointer :: RawDomain -> Int -> State BState ()
 pushPointer dom pos = do
-    BState m cur <- ST.get
-    ST.put $ BState (M.insert dom pos m) cur
+    BState m cur b <- ST.get
+    ST.put $ BState (M.insert dom pos m) cur b
 
-runSPut :: SPut -> ByteString
-runSPut = LC8.toStrict . BB.toLazyByteString . flip ST.evalState initialBState
+appendBuilder :: Builder -> State BState ()
+appendBuilder bb = do
+    BState m cur b <- ST.get
+    ST.put $ BState m cur (b <> bb)
+
+----------------------------------------------------------------
+
+fixedSized :: Int -> (a -> Builder) -> a -> SPut ()
+fixedSized n f v = do
+    addBuilderPosition n
+    appendBuilder $ f v
+
+put8 :: Word8 -> SPut ()
+put8 = fixedSized 1 BB.word8
+
+put16 :: Word16 -> SPut ()
+put16 = fixedSized 2 BB.word16BE
+
+put32 :: Word32 -> SPut ()
+put32 = fixedSized 4 BB.word32BE
+
+putInt8 :: Int -> SPut ()
+putInt8 = fixedSized 1 (BB.int8 . fromIntegral)
+
+putInt16 :: Int -> SPut ()
+putInt16 = fixedSized 2 (BB.int16BE . fromIntegral)
+
+putInt32 :: Int -> SPut ()
+putInt32 = fixedSized 4 (BB.int32BE . fromIntegral)
+
+putReplicate :: Int -> Word8 -> SPut ()
+putReplicate n w =
+    fixedSized n BB.lazyByteString $ LB.replicate (fromIntegral n) w
+
+----------------------------------------------------------------
+
+expectedSized :: (a -> Int) -> (a -> Builder) -> a -> SPut ()
+expectedSized n f v = do
+    addBuilderPosition $ n v
+    appendBuilder $ f v
+
+putShortByteString :: ShortByteString -> SPut ()
+putShortByteString = expectedSized Short.length BB.shortByteString
+
+-- In the case of the TXT record, we need to put the string length
+putLenShortByteString :: ShortByteString -> SPut ()
+putLenShortByteString txt = do
+    putInt8 len
+    putShortByteString txt
+   where
+     len = fromIntegral $ Short.length txt
+
+----------------------------------------------------------------
+
+unexpectedSized :: (Int -> SPut ()) -> SPut () -> SPut ()
+unexpectedSized p s = do
+    let bs = runSPut s
+    p $ BS.length bs
+    s
+

--- a/dnsext-types/DNS/Types/Message.hs
+++ b/dnsext-types/DNS/Types/Message.hs
@@ -4,9 +4,6 @@
 
 module DNS.Types.Message where
 
-import qualified Data.ByteString.Builder as BB
-import qualified Data.ByteString.Lazy.Char8 as LC8
-
 import DNS.StateBinary
 import DNS.Types.Dict
 import DNS.Types.Domain
@@ -98,19 +95,20 @@ data DNSMessage = DNSMessage {
 --   generates any kind of query.
 type Identifier = Word16
 
-putDNSMessage :: DNSMessage -> SPut
-putDNSMessage msg = putHeader hd
-                    <> putNums
-                    <> mconcat (map putQuestion qs)
-                    <> mconcat (map putRR an)
-                    <> mconcat (map putRR au)
-                    <> mconcat (map putRR ad)
+putDNSMessage :: DNSMessage -> SPut ()
+putDNSMessage msg = do
+    putHeader hd
+    putNums
+    mapM_ putQuestion qs
+    mapM_ putRR an
+    mapM_ putRR au
+    mapM_ putRR ad
   where
-    putNums = mconcat $ fmap putInt16 [ length qs
-                                      , length an
-                                      , length au
-                                      , length ad
-                                      ]
+    putNums = mapM_ putInt16 [ length qs
+                             , length an
+                             , length au
+                             , length ad
+                             ]
     putRR = putResourceRecord Compression
     hm = header msg
     fl = flags hm
@@ -295,9 +293,10 @@ data DNSFlags = DNSFlags {
   , chkDisable   :: Bool   -- ^ CD (Checking Disabled) bit - (RFC4035, Section 3.2.2).
   } deriving (Eq, Show)
 
-putHeader :: DNSHeader -> SPut
-putHeader hdr = putIdentifier (identifier hdr)
-             <> putDNSFlags (flags hdr)
+putHeader :: DNSHeader -> SPut ()
+putHeader hdr = do
+    putIdentifier $ identifier hdr
+    putDNSFlags $ flags hdr
   where
     putIdentifier = put16
 
@@ -325,7 +324,7 @@ defaultDNSFlags = DNSFlags
          , rcode        = NoErr
          }
 
-putDNSFlags :: DNSFlags -> SPut
+putDNSFlags :: DNSFlags -> SPut ()
 putDNSFlags DNSFlags{..} = put16 word
   where
     set :: Word16 -> State Word16 ()
@@ -553,10 +552,11 @@ data Question = Question {
   , qclass :: CLASS
   } deriving (Eq, Show)
 
-putQuestion :: Question -> SPut
-putQuestion Question{..} = putDomain Compression qname
-                        <> put16 (fromTYPE qtype)
-                        <> putCLASS qclass
+putQuestion :: Question -> SPut ()
+putQuestion Question{..} = do
+    putDomain Compression qname
+    put16 (fromTYPE qtype)
+    putCLASS qclass
 
 ----------------------------------------------------------------
 
@@ -567,7 +567,7 @@ type CLASS = Word16
 classIN :: CLASS
 classIN = 1
 
-putCLASS :: CLASS -> SPut
+putCLASS :: CLASS -> SPut ()
 putCLASS = put16
 
 getCLASS :: SGet CLASS
@@ -594,22 +594,16 @@ type AuthorityRecords = [ResourceRecord]
 -- | Type for resource records in the additional section.
 type AdditionalRecords = [ResourceRecord]
 
-putResourceRecord :: CanonicalFlag -> ResourceRecord -> SPut
-putResourceRecord cf ResourceRecord{..} = mconcat [
+putResourceRecord :: CanonicalFlag -> ResourceRecord -> SPut ()
+putResourceRecord cf ResourceRecord{..} = do
     putDomain cf rrname
-  , putTYPE      rrtype
-  , putCLASS     rrclass
-  , putSeconds   rrttl
-  , putResourceRData rdata
-  ]
+    putTYPE      rrtype
+    putCLASS     rrclass
+    putSeconds   rrttl
+    putResourceRData rdata
   where
-    putResourceRData :: RData -> SPut
-    putResourceRData (RData rd) = do
-        addBuilderPosition 2 -- "simulate" putInt16
-        rDataBuilder <- putResourceData cf rd
-        let rdataLength = fromIntegral . LC8.length . BB.toLazyByteString $ rDataBuilder
-        let rlenBuilder = BB.int16BE rdataLength
-        return $ rlenBuilder <> rDataBuilder
+    putResourceRData :: RData -> SPut ()
+    putResourceRData (RData rd) = unexpectedSized putInt16 $ putResourceData cf rd
 
 getResourceRecords :: Int -> SGet [ResourceRecord]
 getResourceRecords n = replicateM n getResourceRecord

--- a/dnsext-types/DNS/Types/Message.hs
+++ b/dnsext-types/DNS/Types/Message.hs
@@ -603,7 +603,7 @@ putResourceRecord cf ResourceRecord{..} = do
     putResourceRData rdata
   where
     putResourceRData :: RData -> SPut ()
-    putResourceRData (RData rd) = unexpectedSized putInt16 $ putResourceData cf rd
+    putResourceRData (RData rd) = with16Length $ putResourceData cf rd
 
 getResourceRecords :: Int -> SGet [ResourceRecord]
 getResourceRecords n = replicateM n getResourceRecord

--- a/dnsext-types/DNS/Types/Opaque/Internal.hs
+++ b/dnsext-types/DNS/Types/Opaque/Internal.hs
@@ -72,17 +72,17 @@ foldr f ini (Opaque sbs) = Short.foldr f ini sbs
 
 ----------------------------------------------------------------
 
-putOpaque :: Opaque -> SPut
+putOpaque :: Opaque -> SPut ()
 putOpaque (Opaque o) = putShortByteString o
 
 getOpaque :: Int -> SGet Opaque
 getOpaque len = Opaque <$> getNShortByteString len
 
-putLenOpaque :: Opaque -> SPut
-putLenOpaque (Opaque o) =
+putLenOpaque :: Opaque -> SPut ()
+putLenOpaque (Opaque o) = do
     -- put the length of the given string
     putInt8 (fromIntegral $ Short.length o)
- <> putShortByteString o
+    putShortByteString o
 
 getLenOpaque :: SGet Opaque
 getLenOpaque = Opaque <$> (getInt8 >>= getNShortByteString)

--- a/dnsext-types/DNS/Types/Seconds.hs
+++ b/dnsext-types/DNS/Types/Seconds.hs
@@ -20,9 +20,8 @@ instance Show Seconds where
                          in show j ++ mul " min" j
           | otherwise  =              mul  "sec" i
 
-putSeconds :: Seconds -> SPut
+putSeconds :: Seconds -> SPut ()
 putSeconds (Seconds n) = put32 n
 
 getSeconds :: SGet Seconds
 getSeconds = Seconds <$> get32
-

--- a/dnsext-types/DNS/Types/Type.hs
+++ b/dnsext-types/DNS/Types/Type.hs
@@ -220,5 +220,5 @@ addType typ name = do
 getTYPE :: SGet TYPE
 getTYPE = toTYPE <$> get16
 
-putTYPE :: TYPE -> SPut
+putTYPE :: TYPE -> SPut ()
 putTYPE x = put16 $ fromTYPE x

--- a/dnsext-types/test/DecodeSpec.hs
+++ b/dnsext-types/test/DecodeSpec.hs
@@ -45,6 +45,8 @@ test_mx = "f03681800001000100000001036d6577036f726700000f0001c00c000f000100000df
 -- as a pointer to the question domain.
 test_soa_in :: DNSMessage
 test_soa_in =
+    -- Using "hostmaster.example.com." instead of "hostmaster@example.com."
+    -- for full compression.
     let soard = rd_soa "ns1.example.com." "hostmaster.example.com." 0 0 0 0 0
         soarr = ResourceRecord "example.com." SOA 1 3600 soard
      in defaultResponse { question = [Question "hostmaster.example.com." A classIN]


### PR DESCRIPTION
This PR changes `SPut` from `Monoid` to `Monad`.
So, it becomes `SPut a`.
With this, we can use `do` instead of `mconcat`.

The old builder builds `RData` twice to get its length in advance.
This PR stacks `(Position,Length)` to the state and adjust length parts later unsafely.