### PR TITLE
Overhauling Domain

### DIFF
--- a/dnsext-dnssec/test/RoundTripSpec.hs
+++ b/dnsext-dnssec/test/RoundTripSpec.hs
@@ -74,11 +74,7 @@ genOpaque :: Gen Opaque
 genOpaque = Opaque.fromByteString <$> elements [ "", "a", "a.b", "abc", "a.b.c", "a\\.b.c", "\\001.a.b", "\\$.a.b" ]
 
 genDomain :: Gen Domain
-genDomain = addRoot <$> genDomainString
-  where
-    genDomainString :: Gen Domain
-    genDomainString = elements
-        ["", "a", "a.b", "abc", "a.b.c", "a\\.b.c", "\\001.a.b", "\\$.a.b"]
+genDomain = elements [".", "a.", "a.b.", "abc.", "a.b.c.", "a\\.b.c.", "\\001.a.b.", "\\$.a.b."]
 
 genWord16 :: Gen Word16
 genWord16 = arbitrary

--- a/dnsext-do53/DNS/Do53/Do53.hs
+++ b/dnsext-do53/DNS/Do53/Do53.hs
@@ -80,7 +80,6 @@ type UdpRslv = Int -- Retry
 --
 resolve :: Resolver -> Domain -> TYPE -> Rslv0
 resolve rlv dom typ qctls rcv
-  | isIllegal dom = return $ Left IllegalDomain
   | typ == AXFR   = return $ Left InvalidAXFRLookup
   | onlyOne       = resolveOne        (head nss) (head gens) q tm retry ctls rcv
   | concurrent    = resolveConcurrent nss        gens        q tm retry ctls rcv

--- a/dnsext-do53/DNS/Do53/Do53.hs
+++ b/dnsext-do53/DNS/Do53/Do53.hs
@@ -86,7 +86,7 @@ resolve rlv dom typ qctls rcv
   | concurrent    = resolveConcurrent nss        gens        q tm retry ctls rcv
   | otherwise     = resolveSequential nss        gens        q tm retry ctls rcv
   where
-    q = Question (addRoot dom) typ classIN
+    q = Question dom typ classIN
 
     gens = NE.toList $ genIds rlv
 

--- a/dnsext-do53/DNS/Do53/LookupX.hs
+++ b/dnsext-do53/DNS/Do53/LookupX.hs
@@ -298,7 +298,7 @@ lookupRDNS rlv ip = lookupPTR rlv dom
   where
     octets = map (fromString . show ) $ fromIPv4 ip
     reverse_ip = Short.intercalate "." (reverse octets)
-    dom = ciName (reverse_ip <> ".in-addr.arpa")
+    dom = fromRepresentation (reverse_ip <> ".in-addr.arpa")
 
 ----------------------------------------------------------------
 

--- a/dnsext-do53/DNS/Do53/Memo.hs
+++ b/dnsext-do53/DNS/Do53/Memo.hs
@@ -33,14 +33,10 @@ newCache delay = R.mkReaper R.defaultReaperSettings {
   }
 
 lookupCache :: Key -> Cache -> IO (Maybe (Prio, Entry))
-lookupCache (dom,typ) reaper = PSQ.lookup key <$> R.reaperRead reaper
-  where
-    key = (addRoot dom, typ)
+lookupCache key reaper = PSQ.lookup key <$> R.reaperRead reaper
 
 insertCache :: Key -> Prio -> Entry -> Cache -> IO ()
-insertCache (dom,typ) tim ent reaper = R.reaperAdd reaper (key,tim,ent)
-  where
-    key = (addRoot dom, typ)
+insertCache key tim ent reaper = R.reaperAdd reaper (key,tim,ent)
 
 -- Theoretically speaking, atMostView itself is good enough for pruning.
 -- But auto-update assumes a list based db which does not provide atMost

--- a/dnsext-full-resolver/DNS/Cache/Cache.hs
+++ b/dnsext-full-resolver/DNS/Cache/Cache.hs
@@ -37,8 +37,6 @@ import Data.Maybe (isJust)
 import Data.Either (partitionEithers)
 import Data.List (group, groupBy, sortOn, uncons)
 import Data.Int (Int64)
-import qualified Data.ByteString.Short as Short
-import Data.Word8 (isAscii)
 
 -- dns packages
 import Data.OrdPSQ (OrdPSQ)
@@ -261,10 +259,8 @@ fromRDatas rds = rds `listseq` Just (Right rds)
 rrSetKey :: ResourceRecord -> Maybe (Key, TTL)
 rrSetKey (ResourceRecord rrname rrtype rrclass rrttl rd)
   | rrclass == DNS.classIN &&
-    DNS.rdataType rd == rrtype &&
-    DNS.checkDomain (Short.all isAscii) rrname
-      =  Just (Key rrname rrtype rrclass, rrttl)
-  | otherwise                 =  Nothing
+    DNS.rdataType rd == rrtype = Just (Key rrname rrtype rrclass, rrttl)
+  | otherwise                  = Nothing
 
 takeRRSet :: [ResourceRecord] -> Maybe ((Key -> TTL -> CRSet -> a) -> a)
 takeRRSet []        =    Nothing

--- a/dnsext-full-resolver/DNS/Cache/Iterative.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative.hs
@@ -80,12 +80,10 @@ normalizeName = normalize
 -- nomalize (domain) name to absolute name
 normalize :: Domain -> Maybe Domain
 normalize s
-  | s == "."    = Just "."
+  | s == "."   = Just "."
   -- empty part is not valid, empty name is not valid
-  | validate rn = Just nn
-  | otherwise   = Nothing  -- not valid
-  where
-    (rn, nn) = (DNS.dropRoot s, DNS.addRoot s)
+  | validate s = Just s
+  | otherwise  = Nothing  -- not valid
 
 -----
 
@@ -246,11 +244,11 @@ parseV6RevDomain dom = do
 
 -- show IPv4 reverse-lookup domain from 8bit-parts
 showV4RevDomain :: [Int] -> Domain
-showV4RevDomain parts = DNS.ciName $ intercalate "." (map show $ reverse parts) ++ ".in-addr.arpa."
+showV4RevDomain parts = DNS.fromRepresentation $ intercalate "." (map show $ reverse parts) ++ ".in-addr.arpa."
 
 -- parse IPv6 reverse-lookup domain from 4bit-parts
 showV6RevDomain :: [Int] -> Domain
-showV6RevDomain parts = DNS.ciName $ intercalate "." (map (`showHex` "") $ reverse parts) ++ ".ip6.arpa."
+showV6RevDomain parts = DNS.fromRepresentation $ intercalate "." (map (`showHex` "") $ reverse parts) ++ ".ip6.arpa."
 
 -- make IPv4-address and mask-length from prefix 8bit-parts
 withMaskLenV4 :: [Int] -> (IPv4, Int)

--- a/dnsext-full-resolver/DNS/Cache/ServerMonitor.hs
+++ b/dnsext-full-resolver/DNS/Cache/ServerMonitor.hs
@@ -178,7 +178,7 @@ console params cxt (pQSizeList, ucacheQSize, logQSize) expires flushLog (issueQu
     parseCmd ws  =  case ws of
       "param" : _ ->  Just Param
       "find" : s : _      ->  Just $ Find s
-      ["lookup", n, typ]  ->  Lookup (DNS.ciName n) <$> parseTYPE typ
+      ["lookup", n, typ]  ->  Lookup (DNS.fromRepresentation n) <$> parseTYPE typ
       "status" : _  ->  Just Status
       "expire" : args -> case args of
         []     ->  Just $ Expire 0

--- a/dnsext-full-resolver/dug/Operation.hs
+++ b/dnsext-full-resolver/dug/Operation.hs
@@ -20,7 +20,7 @@ operate server domain type_ controls = do
 
 operate_ :: ResolvConf -> HostName -> TYPE -> IO (Either DNSError DNSMessage)
 operate_ conf name typ = DNS.withResolver conf $ \resolver ->
-  DNS.lookupRaw resolver (DNS.ciName name) typ
+  DNS.lookupRaw resolver (DNS.fromRepresentation name) typ
 
 getCustomConf :: Maybe HostName -> QueryControls -> IO ResolvConf
 getCustomConf mayServer controls = do
@@ -43,7 +43,7 @@ getCustomConf mayServer controls = do
     queryName :: String -> IO IP
     queryName sname = do
       as <- DNS.withResolver DNS.defaultResolvConf $ \resolver -> do
-        let dom = DNS.ciName sname
+        let dom = DNS.fromRepresentation sname
         eA  <- DNS.lookupA    resolver dom
         eQA <- DNS.lookupAAAA resolver dom
         let catAs = do

--- a/dnsext-full-resolver/dug/Output.hs
+++ b/dnsext-full-resolver/dug/Output.hs
@@ -90,7 +90,7 @@ putQS qs = do
 
 qq :: Printer Question
 qq Question{..} = do
-  semi *> string (origName qname)
+  semi *> string (toRepresentation qname)
   tab
   tab
   string $ cls qclass
@@ -119,7 +119,7 @@ rrs name rs = do
 
 rr :: Printer ResourceRecord
 rr ResourceRecord{..} = do
-  string $ origName rrname
+  string $ toRepresentation rrname
   tab
   string $ show rrttl
   tab

--- a/dnsext-full-resolver/test/CacheProp.hs
+++ b/dnsext-full-resolver/test/CacheProp.hs
@@ -48,7 +48,7 @@ nameList =
   ]
 
 sbsDomainList :: [Domain]
-sbsDomainList = map DNS.ciName domainList
+sbsDomainList = map DNS.fromRepresentation domainList
 
 v4List :: Read a => [a]
 v4List = map read [ "192.168.10.1", "192.168.10.2", "192.168.10.3", "192.168.10.4" ]
@@ -58,7 +58,7 @@ v6List = map read [ "fe80::000a:0001", "fe80::000a:0002", "fe80::000a:0003", "fe
 
 nsList :: [Domain]
 nsList =
-  map DNS.ciName
+  map DNS.fromRepresentation
   [ "ns1.example.com.", "ns2.example.com.", "ns3.example.com."
   , "ns4.example.com.", "ns5.example.com." ]
 
@@ -139,8 +139,8 @@ genCRsRec = do
         | typ `elem` [NS, SOA, MX]  =  domainList
         | otherwise                 =  nameList
   lbl <- elements labelList
-  (,) (Key (DNS.ciName lbl) typ DNS.classIN, genCrs)
-    <$> (DNS.ciName <$> toULString lbl)
+  (,) (Key (DNS.fromRepresentation lbl) typ DNS.classIN, genCrs)
+    <$> (DNS.fromRepresentation <$> toULString lbl)
 
 genCRsPair :: Gen (Key, Gen CRSet)
 genCRsPair = fst <$> genCRsRec

--- a/dnsext-types/DNS/StateBinary/SGet.hs
+++ b/dnsext-types/DNS/StateBinary/SGet.hs
@@ -53,7 +53,7 @@ type SGet = StateT PState (AT.Parser ByteString)
 
 -- | Parser state
 data PState = PState {
-    pstDomain :: IntMap RawDomain
+    pstDomain :: IntMap [RawDomain]
   , pstPosition :: Int
   , pstInput :: ByteString
   , pstAtTime  :: Int64
@@ -79,12 +79,12 @@ addPosition n | n < 0 = failSGet "internal error: negative position increment"
         failSGet "malformed or truncated input"
     ST.put $ PState dom pos' inp t
 
-pushDomain :: Int -> RawDomain -> SGet ()
+pushDomain :: Int -> [RawDomain] -> SGet ()
 pushDomain n d = do
     PState dom pos inp t <- ST.get
     ST.put $ PState (IM.insert n d dom) pos inp t
 
-popDomain :: Int -> SGet (Maybe RawDomain)
+popDomain :: Int -> SGet (Maybe [RawDomain])
 popDomain n = ST.gets (IM.lookup n . pstDomain)
 
 ----------------------------------------------------------------

--- a/dnsext-types/DNS/StateBinary/SPut.hs
+++ b/dnsext-types/DNS/StateBinary/SPut.hs
@@ -78,7 +78,7 @@ type Position = Int
 
 -- | Builder state
 data BState = BState {
-    bstDomain   :: Map RawDomain Int
+    bstDomain   :: Map [RawDomain] Int
   , bstPosition :: Position
   , bstBuilder  :: Builder
   , bstFixLen   :: [(Position, Int)]
@@ -97,10 +97,10 @@ addBuilderPosition n = do
     BState m cur b fl <- ST.get
     ST.put $ BState m (cur+n) b fl
 
-popPointer :: RawDomain -> State BState (Maybe Int)
+popPointer :: [RawDomain] -> State BState (Maybe Int)
 popPointer dom = ST.gets (M.lookup dom . bstDomain)
 
-pushPointer :: RawDomain -> Int -> State BState ()
+pushPointer :: [RawDomain] -> Int -> State BState ()
 pushPointer dom pos = do
     BState m cur b fl <- ST.get
     ST.put $ BState (M.insert dom pos m) cur b fl

--- a/dnsext-types/DNS/Types.hs
+++ b/dnsext-types/DNS/Types.hs
@@ -131,7 +131,7 @@ module DNS.Types (
   , od_ecsGeneric
   , od_unknown
   -- * Basic types
-  , CaseInsensitiveName(..)
+  , IsRepresentation(..)
   -- ** Domain
   , Domain
   , putDomain

--- a/dnsext-types/DNS/Types.hs
+++ b/dnsext-types/DNS/Types.hs
@@ -134,7 +134,6 @@ module DNS.Types (
   , IsRepresentation(..)
   -- ** Domain
   , Domain
-  , checkDomain
   , superDomains
   , isSubDomainOf
   -- ** Mailbox

--- a/dnsext-types/DNS/Types.hs
+++ b/dnsext-types/DNS/Types.hs
@@ -137,7 +137,6 @@ module DNS.Types (
   , (<.>)
   , checkDomain
   , modifyDomain
-  , isIllegal
   , superDomains
   , isSubDomainOf
   -- ** Mailbox

--- a/dnsext-types/DNS/Types.hs
+++ b/dnsext-types/DNS/Types.hs
@@ -139,7 +139,6 @@ module DNS.Types (
   , isSubDomainOf
   -- ** Mailbox
   , Mailbox
-  , checkMailbox
   -- ** Opaque
   , Opaque
   -- ** TYPE

--- a/dnsext-types/DNS/Types.hs
+++ b/dnsext-types/DNS/Types.hs
@@ -134,7 +134,6 @@ module DNS.Types (
   , IsRepresentation(..)
   -- ** Domain
   , Domain
-  , (<.>)
   , checkDomain
   , superDomains
   , isSubDomainOf

--- a/dnsext-types/DNS/Types.hs
+++ b/dnsext-types/DNS/Types.hs
@@ -136,13 +136,11 @@ module DNS.Types (
   , Domain
   , (<.>)
   , checkDomain
-  , modifyDomain
   , superDomains
   , isSubDomainOf
   -- ** Mailbox
   , Mailbox
   , checkMailbox
-  , modifyMailbox
   -- ** Opaque
   , Opaque
   -- ** TYPE

--- a/dnsext-types/DNS/Types.hs
+++ b/dnsext-types/DNS/Types.hs
@@ -134,8 +134,6 @@ module DNS.Types (
   , IsRepresentation(..)
   -- ** Domain
   , Domain
-  , putDomain
-  , getDomain
   , (<.>)
   , checkDomain
   , modifyDomain
@@ -146,8 +144,6 @@ module DNS.Types (
   , Mailbox
   , checkMailbox
   , modifyMailbox
-  , putMailbox
-  , getMailbox
   -- ** Opaque
   , Opaque
   -- ** TYPE

--- a/dnsext-types/DNS/Types.hs
+++ b/dnsext-types/DNS/Types.hs
@@ -139,7 +139,6 @@ module DNS.Types (
   , (<.>)
   , checkDomain
   , modifyDomain
-  , addRoot
   , dropRoot
   , hasRoot
   , isIllegal

--- a/dnsext-types/DNS/Types.hs
+++ b/dnsext-types/DNS/Types.hs
@@ -139,8 +139,6 @@ module DNS.Types (
   , (<.>)
   , checkDomain
   , modifyDomain
-  , dropRoot
-  , hasRoot
   , isIllegal
   , superDomains
   , isSubDomainOf

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -78,7 +78,7 @@ class CaseInsensitiveName a b where
 data Domain = Domain {
     origDomain      :: ShortByteString
   , lowerDomain     :: ShortByteString
-  -- | Ord key for Canonical DNS Name Order
+  -- | Eq and Ord key for Canonical DNS Name Order
   --   https://datatracker.ietf.org/doc/html/rfc4034#section-6.1
   , canonicalLabels :: ~[ShortByteString]
   }
@@ -101,7 +101,7 @@ domain o = Domain {
         | otherwise  -> just
 
 instance Eq Domain where
-    d0 == d1 = lowerDomain d0 == lowerDomain d1
+    d0 == d1 = canonicalLabels d0 == canonicalLabels d1
 
 instance Ord Domain where
     d0 <= d1 = canonicalLabels d0 <= canonicalLabels d1

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -78,6 +78,7 @@ class CaseInsensitiveName a b where
 data Domain = Domain {
     origDomain      :: ShortByteString
   , lowerDomain     :: ShortByteString
+  , origLabels      :: ~[ShortByteString]
   -- | Eq and Ord key for Canonical DNS Name Order
   --   https://datatracker.ietf.org/doc/html/rfc4034#section-6.1
   , canonicalLabels :: ~[ShortByteString]
@@ -87,13 +88,15 @@ domain :: ShortByteString -> Domain
 domain o
   | Short.length o > 255 = E.throw $ DecodeError "The domain length is over 255"
 domain o = Domain {
-    origDomain = o
+    origDomain  = o
   , lowerDomain = n
-  , canonicalLabels = reverse $ labels n
+  , origLabels  = ls
+  , canonicalLabels = reverse ls
   }
   where
-    n = Short.map toLower o
-    labels = unfoldr step
+    ~n = Short.map toLower o
+    ~ls = labels n
+    ~labels = unfoldr step
     step x = case parseLabel _period x of
       Nothing        -> Nothing
       just@(Just (p, _))

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -112,6 +112,14 @@ domainFromWireLabels ls = validateDomain $ Domain {
 instance Eq Domain where
     d0 == d1 = canonicalLabels d0 == canonicalLabels d1
 
+-- | Ordering according to the DNSSEC definition.
+--
+-- >>> ("www.example.jp" :: Domain) >= "example.jp"
+-- True
+-- >>> ("example8.jp" :: Domain) >= "example.jp"
+-- True
+-- >>> ("example.jp" :: Domain) >= "example.com"
+-- True
 instance Ord Domain where
     d0 <= d1 = canonicalLabels d0 <= canonicalLabels d1
 

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -10,7 +10,6 @@ module DNS.Types.Domain (
   , Domain
   , putDomain
   , getDomain
-  , checkDomain
   , superDomains
   , isSubDomainOf
   , Mailbox
@@ -154,9 +153,6 @@ instance IsRepresentation Domain String where
     toRepresentation   = shortToString . representation
     fromWireLabels     = domainFromWireLabels . map fromString
     toWireLabels       = map shortToString . wireLabels
-
-checkDomain :: (ShortByteString -> a) -> Domain -> a
-checkDomain f Domain{..} = f representation
 
 addRoot :: RawDomain -> RawDomain
 addRoot o

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -67,17 +67,20 @@ class IsRepresentation a b where
 -- Examples:
 --
 -- @
--- www.example.org.           -- Ordinary DNS name.
--- \_25.\_tcp.mx1.example.net.  -- TLSA RR initial labels have \_ prefixes.
+-- www.example.org.            -- Ordinary DNS name.
+-- \_25.\_tcp.mx1.example.net. -- TLSA RR initial labels have \_ prefixes.
 -- \\001.exotic.example.       -- First label is Ctrl-A!
--- just\\.one\\.label.example.  -- First label is \"just.one.label\"
+-- just\\.one\\.label.example. -- First label is \"just.one.label\"
 -- @
 --
 
 data Domain = Domain {
+    -- The representation format. Case-sensitive, escaped.
     representation  :: ShortByteString
+    -- Labels in wire format. Case-sensitive, not escaped.
   , wireLabels      :: ~[ShortByteString]
-  -- | Eq and Ord key for Canonical DNS Name Order
+  -- | Eq and Ord key for Canonical DNS Name Order.
+  --   Lower cases, not escaped.
   --   https://datatracker.ietf.org/doc/html/rfc4034#section-6.1
   , canonicalLabels :: ~[ShortByteString]
   }

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -14,7 +14,6 @@ module DNS.Types.Domain (
   , superDomains
   , isSubDomainOf
   , Mailbox
-  , checkMailbox
   , putMailbox
   , getMailbox
   , CanonicalFlag (..)
@@ -261,9 +260,6 @@ instance IsRepresentation Mailbox String where
     toRepresentation   = toRepresentation . fromMailbox
     fromWireLabels     = toMailbox . domainFromWireLabels . map fromString
     toWireLabels       = map shortToString . wireLabels . fromMailbox
-
-checkMailbox :: (ShortByteString -> a) -> Mailbox -> a
-checkMailbox f (Mailbox d) = checkDomain f d
 
 ----------------------------------------------------------------
 

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -13,8 +13,6 @@ module DNS.Types.Domain (
   , (<.>)
   , checkDomain
   , modifyDomain
-  , dropRoot
-  , hasRoot
   , isIllegal
   , superDomains
   , isSubDomainOf
@@ -160,26 +158,11 @@ checkDomain f Domain{..} = f representation
 modifyDomain :: (ShortByteString -> ShortByteString) -> Domain -> Domain
 modifyDomain f Domain{..} = domain $ f representation
 
-hasRoot :: Domain -> Bool
-hasRoot d
-  | Short.null o = False
-  | otherwise    = Short.last o == _period
-  where
-    o = representation d
-
 addRoot :: RawDomain -> RawDomain
 addRoot o
   | Short.null o            = "."
   | Short.last o == _period = o
   | otherwise               = o <> "."
-
-dropRoot :: Domain -> Domain
-dropRoot d
-  | Short.null o            = d
-  | Short.last o == _period = domain $ Short.init o
-  | otherwise               = d
-  where
-   o = representation d
 
 ----------------------------------------------------------------
 

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -12,12 +12,10 @@ module DNS.Types.Domain (
   , getDomain
   , (<.>)
   , checkDomain
-  , modifyDomain
   , superDomains
   , isSubDomainOf
   , Mailbox
   , checkMailbox
-  , modifyMailbox
   , putMailbox
   , getMailbox
   , CanonicalFlag (..)
@@ -152,9 +150,6 @@ infixr 6 <.>
 checkDomain :: (ShortByteString -> a) -> Domain -> a
 checkDomain f Domain{..} = f representation
 
-modifyDomain :: (ShortByteString -> ShortByteString) -> Domain -> Domain
-modifyDomain f Domain{..} = domain $ f representation
-
 addRoot :: RawDomain -> RawDomain
 addRoot o
   | Short.null o            = "."
@@ -251,9 +246,6 @@ instance IsRepresentation Mailbox String where
 
 checkMailbox :: (ShortByteString -> a) -> Mailbox -> a
 checkMailbox f (Mailbox d) = checkDomain f d
-
-modifyMailbox :: (ShortByteString -> ShortByteString) -> Mailbox -> Mailbox
-modifyMailbox f (Mailbox d) = Mailbox $ modifyDomain f d
 
 ----------------------------------------------------------------
 

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -43,25 +43,25 @@ class IsRepresentation a b where
 -- $setup
 -- >>> :set -XOverloadedStrings
 
--- | This type holds the /presentation form/ of fully-qualified DNS domain
--- names encoded as ASCII A-labels, with \'.\' separators between labels.
--- Non-printing characters are escaped as @\\DDD@ (a backslash, followed by
--- three decimal digits). The special characters: @ \", \$, (, ), ;, \@,@ and
--- @\\@ are escaped by prepending a backslash.  The trailing \'.\' is optional
--- on input, but is recommended, and is always added when decoding from
--- /wire form/.
+-- | The type for domain names. This holds both the
+-- /presentation format/ and the /wire format/ internally.
 --
--- The encoding of domain names to /wire form/, e.g. for transmission in a
--- query, requires the input encodings to be valid, otherwise a 'DecodeError'
--- may be thrown. Domain names received in wire form in DNS messages are
--- escaped to this presentation form as part of decoding the 'DNSMessage'.
+-- The representation format is fully-qualified DNS domain names encoded
+-- as ASCII A-labels, with \'.\' separators between labels.
+-- The trailing \'.\' is added if missing.
+-- Non-printing characters are escaped as @\\DDD@ (a backslash,
+-- followed by three decimal digits). The special characters: @ \",
+-- \$, (, ), ;, \@,@ and @\\@ are escaped by prepending a backslash.
 --
--- This form is ASCII-only. Any conversion between A-label 'Text's,
--- and U-label 'Text' happens at whatever layer maps user input to DNS
--- names, or presents /friendly/ DNS names to the user.  Not all users
--- can read all scripts, and applications that default to U-label form
--- should ideally give the user a choice to see the A-label form.
--- Examples:
+-- The representation format is ASCII-only. Any conversion between
+-- A-label 'Text's, and U-label 'Text' happens at whatever layer maps
+-- user input to DNS names, or presents /friendly/ DNS names to the
+-- user.  Not all users can read all scripts, and applications that
+-- default to U-label format should ideally give the user a choice to
+-- see the A-label format.  Examples:
+--
+-- A 'DecodeError' may be thrown when creating from the representation
+-- format or decoding the wire format.
 --
 -- @
 -- www.example.org.            -- Ordinary DNS name.
@@ -186,18 +186,9 @@ isIllegal d
 
 ----------------------------------------------------------------
 
--- | Type for a mailbox encoded on the wire as a DNS name, but the first label
--- is conceptually the local part of an email address, and may contain internal
--- periods that are not label separators. Therefore, in mailboxes \@ is used as
--- the separator between the first and second labels, and any \'.\' characters
--- in the first label are not escaped.  The encoding is otherwise the same as
--- 'Domain' above. This is most commonly seen in the /rname/ of @SOA@ records,
--- and is also employed in the @mbox-dname@ field of @RP@ records.
--- On input, if there is no unescaped \@ character in the 'Mailbox', it is
--- reparsed with \'.\' as the first label separator. Thus the traditional
--- format with all labels separated by dots is also accepted, but decoding from
--- wire form always uses \@ between the first label and the domain-part of the
--- address.  Examples:
+-- | The type for mailbox whose internal is just 'Domain'.
+--   The representation format must include \'@\'.
+-- Examples:
 --
 -- @
 -- hostmaster\@example.org.  -- First label is simply @hostmaster@

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -10,7 +10,6 @@ module DNS.Types.Domain (
   , Domain
   , putDomain
   , getDomain
-  , (<.>)
   , checkDomain
   , superDomains
   , isSubDomainOf
@@ -122,6 +121,12 @@ instance Show Domain where
 instance IsString Domain where
     fromString = fromRepresentation
 
+-- | Appending two domains.
+--
+-- >>> ("www" :: Domain) <> "example.com"
+-- "www.example.com."
+-- >>> ("www." :: Domain) <> "example.com."
+-- "www.example.com."
 instance Semigroup Domain where
     d0 <> d1 = domainFromWireLabels (wireLabels d0 <> wireLabels d1)
 
@@ -142,18 +147,6 @@ instance IsRepresentation Domain String where
     toRepresentation   = shortToString . representation
     fromWireLabels     = domainFromWireLabels . map fromString
     toWireLabels       = map shortToString . wireLabels
-
--- | append operator using '.'
---
--- >>> "www" <.> "example.com"
--- "www.example.com."
--- >>> "com" <.> "."
--- "com."
-(<.>) :: Domain -> Domain -> Domain
-x <.> "." = x
-x <.> y   = x <> "." <> y
-
-infixr 6 <.>
 
 checkDomain :: (ShortByteString -> a) -> Domain -> a
 checkDomain f Domain{..} = f representation

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -553,9 +553,13 @@ shortToString = C8.unpack . Short.fromShort
 -- ["www.example.com.","example.com.","com."]
 -- >>> superDomains "www.example.com."
 -- ["www.example.com.","example.com.","com."]
+-- >>> superDomains "com."
+-- ["com."]
+-- >>> superDomains "."
+-- []
 superDomains :: Domain -> [Domain]
 superDomains d = case wireLabels d of
-  []   -> [d]
+  []   -> []
   [_]  -> [d]
   _:ls -> d : map domainFromWireLabels (init $ tails ls)
 

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -42,7 +42,6 @@ import qualified DNS.Types.Parser as P
 class CaseInsensitiveName a b where
     ciName    :: b -> a
     origName  :: a -> b
-    lowerName :: a -> b
 
 -- $setup
 -- >>> :set -XOverloadedStrings
@@ -77,7 +76,6 @@ class CaseInsensitiveName a b where
 
 data Domain = Domain {
     representation  :: ShortByteString
-  , lowerDomain     :: ShortByteString
   , wireLabels      :: ~[ShortByteString]
   -- | Eq and Ord key for Canonical DNS Name Order
   --   https://datatracker.ietf.org/doc/html/rfc4034#section-6.1
@@ -89,7 +87,6 @@ domain o
   | Short.length o > 255 = E.throw $ DecodeError "The domain length is over 255"
 domain o = Domain {
     representation  = o
-  , lowerDomain     = l
   , wireLabels      = ls
   , canonicalLabels = reverse ls
   }
@@ -120,17 +117,14 @@ instance Semigroup Domain where
 instance CaseInsensitiveName Domain ShortByteString where
     ciName o = domain o
     origName  d = representation d
-    lowerName d = lowerDomain d
 
 instance CaseInsensitiveName Domain ByteString where
     ciName o = domain $ Short.toShort o
     origName  d = Short.fromShort $ representation d
-    lowerName d = Short.fromShort $ lowerDomain d
 
 instance CaseInsensitiveName Domain String where
     ciName o = domain $ fromString o
     origName  d = shortToString $ representation d
-    lowerName d = shortToString $ lowerDomain d
 
 -- | append operator using '.'
 --
@@ -236,7 +230,6 @@ mailbox o
   | Short.length o > 255 = E.throw $ DecodeError "The mailbox length is over 255"
 mailbox o = Mailbox $ Domain {
     representation  = o
-  , lowerDomain = l
   , wireLabels  = ls
   , canonicalLabels = reverse ls
   }
@@ -255,17 +248,14 @@ mailbox o = Mailbox $ Domain {
 instance CaseInsensitiveName Mailbox ShortByteString where
     ciName o = mailbox o
     origName  (Mailbox d) = origName d
-    lowerName (Mailbox d) = lowerName d
 
 instance CaseInsensitiveName Mailbox ByteString where
     ciName o = mailbox $ Short.toShort o
     origName  (Mailbox d) = origName d
-    lowerName (Mailbox d) = lowerName d
 
 instance CaseInsensitiveName Mailbox String where
     ciName o = mailbox $ fromString o
     origName  (Mailbox d) = origName d
-    lowerName (Mailbox d) = lowerName d
 
 checkMailbox :: (ShortByteString -> a) -> Mailbox -> a
 checkMailbox f (Mailbox d) = checkDomain f d

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -560,13 +560,13 @@ isSpecial sep w = w == sep || elem w escSpecials
 -- Note: the separator is assumed to be either '.' or '@' and so not matched by
 -- any of the first three fast-path 'True' cases.
 isPlain :: Word8 -> Word8 -> Bool
-isPlain sep w | w >= _del                  = False -- <DEL> + non-ASCII
-              | w >  _backslash            = True  -- ']'..'_'..'a'..'z'..'~'
-              | w >= _0  && w < _semicolon = True  -- '0'..'9'..':'
-              | w >  _at && w < _backslash = True  -- 'A'..'Z'..'['
-              | w <= _space                = False -- non-printables
-              | isSpecial sep       w      = False -- one of the specials
-              | otherwise                  = True  -- plain punctuation
+isPlain sep w | w >= _del                    = False -- <DEL> + non-ASCII
+              | w >= _bracketright           = True  -- ']'..'_'..'a'..'z'..'~'
+              | w >= _A && w <= _bracketleft = True  -- 'A'..'Z'..'['
+              | w >= _0 && w <= _colon       = True  -- '0'..'9'..':'
+              | w <= _space                  = False -- non-printables
+              | isSpecial sep w              = False -- one of the specials
+              | otherwise                    = True  -- plain punctuation
 
 ----------------------------------------------------------------
 

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -564,7 +564,7 @@ shortToString = C8.unpack . Short.fromShort
 
 ----------------------------------------------------------------
 
--- |
+-- | Creating super domains.
 --
 -- >>> superDomains "www.example.com"
 -- ["www.example.com.","example.com.","com."]
@@ -580,7 +580,7 @@ superDomains d = case wireLabels d of
   [_]  -> [d]
   _:ls -> d : map domainFromWireLabels (init $ tails ls)
 
--- |
+-- | Sub-domain or not.
 --
 -- >>> "www.example.com." `isSubDomainOf` "."
 -- True

--- a/dnsext-types/test/DecodeSpec.hs
+++ b/dnsext-types/test/DecodeSpec.hs
@@ -43,18 +43,8 @@ test_mx = "f03681800001000100000001036d6577036f726700000f0001c00c000f000100000df
 -- Message with question domain == SOA rname, testing correct decoding of
 -- of the rname to presentation form when it encoded in compressed form
 -- as a pointer to the question domain.
-test_soa_in :: DNSMessage
-test_soa_in =
-    -- Using "hostmaster.example.com." instead of "hostmaster@example.com."
-    -- for full compression.
-    let soard = rd_soa "ns1.example.com." "hostmaster@example.com." 0 0 0 0 0
-        soarr = ResourceRecord "example.com." SOA 1 3600 soard
-     in defaultResponse { question = [Question "hostmaster.example.com." A classIN]
-                        , authority = [soarr] }
-
--- Expected decoded presentation form of the 'test_soa' message.
-test_soa_out :: DNSMessage
-test_soa_out =
+test_soa :: DNSMessage
+test_soa =
     let soard = rd_soa "ns1.example.com." "hostmaster@example.com." 0 0 0 0 0
         soarr = ResourceRecord "example.com." SOA 1 3600 soard
      in defaultResponse { question = [Question "hostmaster.example.com." A classIN]
@@ -86,12 +76,12 @@ spec = do
                 Left (DecodeError {}) -> True
                 _ -> error "Excess input not detected"
         it "soa mailbox presentation form" $
-            case encode test_soa_in of
+            case encode test_soa of
                 enc | enc /= fromHexString test_soa_bytes
                     -> error "Unexpected test_soa encoding"
                     | otherwise -> case decode enc of
                         Left err  -> error $ "Error decoding test_soa: " ++ show err
-                        Right m | m /= test_soa_out
+                        Right m | m /= test_soa
                                   -> error $ "Wrong decode of test_soa: " ++ show m
                                 | otherwise -> True
 

--- a/dnsext-types/test/DecodeSpec.hs
+++ b/dnsext-types/test/DecodeSpec.hs
@@ -47,7 +47,7 @@ test_soa_in :: DNSMessage
 test_soa_in =
     -- Using "hostmaster.example.com." instead of "hostmaster@example.com."
     -- for full compression.
-    let soard = rd_soa "ns1.example.com." "hostmaster.example.com." 0 0 0 0 0
+    let soard = rd_soa "ns1.example.com." "hostmaster@example.com." 0 0 0 0 0
         soarr = ResourceRecord "example.com." SOA 1 3600 soard
      in defaultResponse { question = [Question "hostmaster.example.com." A classIN]
                         , authority = [soarr] }

--- a/dnsext-types/test/RoundTripSpec.hs
+++ b/dnsext-types/test/RoundTripSpec.hs
@@ -142,7 +142,7 @@ genMailbox = ciName . (<> ".") <$> genMboxString
   where
     genMboxString :: Gen String
     genMboxString = elements
-        ["", "a", "a@b", "abc", "a@b.c", "first.last@example.org"]
+        ["a@b", "a@b.c", "first.last@example.org"]
 
 genDNSHeader :: Word16 -> Gen DNSHeader
 genDNSHeader maxrc = DNSHeader <$> genWord16 <*> genDNSFlags maxrc

--- a/dnsext-types/test/RoundTripSpec.hs
+++ b/dnsext-types/test/RoundTripSpec.hs
@@ -131,18 +131,10 @@ genOpaque :: Gen Opaque
 genOpaque = Opaque.fromByteString <$> elements [ "", "a", "a.b", "abc", "a.b.c", "a\\.b.c", "\\001.a.b", "\\$.a.b" ]
 
 genDomain :: Gen Domain
-genDomain = addRoot <$> genDomainString
-  where
-    genDomainString :: Gen Domain
-    genDomainString = elements
-        ["", "a", "a.b", "abc", "a.b.c", "a\\.b.c", "\\001.a.b", "\\$.a.b"]
+genDomain = elements [".", "a.", "a.b.", "abc.", "a.b.c.", "a\\.b.c.", "\\001.a.b.", "\\$.a.b."]
 
 genMailbox :: Gen Mailbox
-genMailbox = fromRepresentation . (<> ".") <$> genMboxString
-  where
-    genMboxString :: Gen String
-    genMboxString = elements
-        ["a@b", "a@b.c", "first.last@example.org"]
+genMailbox = elements ["a@b.", "a@b.c.", "first.last@example.org."]
 
 genDNSHeader :: Word16 -> Gen DNSHeader
 genDNSHeader maxrc = DNSHeader <$> genWord16 <*> genDNSFlags maxrc

--- a/dnsext-types/test/RoundTripSpec.hs
+++ b/dnsext-types/test/RoundTripSpec.hs
@@ -138,7 +138,7 @@ genDomain = addRoot <$> genDomainString
         ["", "a", "a.b", "abc", "a.b.c", "a\\.b.c", "\\001.a.b", "\\$.a.b"]
 
 genMailbox :: Gen Mailbox
-genMailbox = ciName . (<> ".") <$> genMboxString
+genMailbox = fromRepresentation . (<> ".") <$> genMboxString
   where
     genMboxString :: Gen String
     genMboxString = elements


### PR DESCRIPTION
We clearly separate representation format and wire format. 
The domain can be created from both format.
Validation is done when creating.
The representation format is ensured having the trailing dot.
