### PR TITLE
New CanonicalFlag and putCompressedDomain

### DIFF
--- a/dnsext-dnssec/DNS/SEC/Types.hs
+++ b/dnsext-dnssec/DNS/SEC/Types.hs
@@ -114,7 +114,7 @@ data RD_RRSIG = RD_RRSIG {
 
 instance ResourceData RD_RRSIG where
     resourceDataType _ = RRSIG
-    putResourceData _ RD_RRSIG{..} = do
+    putResourceData cf RD_RRSIG{..} = do
         putTYPE    rrsig_type
         putPubAlg  rrsig_pubalg
         put8       rrsig_num_labels
@@ -122,7 +122,7 @@ instance ResourceData RD_RRSIG where
         putDnsTime rrsig_expiration
         putDnsTime rrsig_inception
         put16      rrsig_key_tag
-        putDomain  Canonical rrsig_zone
+        putDomain  cf rrsig_zone
         putOpaque  rrsig_signature
 
 get_rrsig :: Int -> SGet RD_RRSIG
@@ -188,8 +188,8 @@ data RD_NSEC = RD_NSEC {
 
 instance ResourceData RD_NSEC where
     resourceDataType _ = NSEC
-    putResourceData _ RD_NSEC{..} = do
-        putDomain Canonical nsecNextDomain
+    putResourceData cf RD_NSEC{..} = do
+        putDomain cf nsecNextDomain
         putNsecTypes nsecTypes
 
 get_nsec :: Int -> SGet RD_NSEC

--- a/dnsext-svcb/DNS/SVCB.hs
+++ b/dnsext-svcb/DNS/SVCB.hs
@@ -68,11 +68,11 @@ data RD_SVCB = RD_SVCB {
 
 instance ResourceData RD_SVCB where
     resourceDataType _ = SVCB
-    putResourceData _ RD_SVCB{..} = do
+    putResourceData cf RD_SVCB{..} = do
         put16 svcb_priority
         -- https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-11#section-2.2
         -- "the uncompressed, fully-qualified TargetName"
-        putDomain Canonical svcb_target
+        putDomain cf svcb_target
         let SvcParams m = svcb_params
         void $ M.foldrWithKey f (return ())  m
       where

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -8,14 +8,16 @@
 module DNS.Types.Domain (
     IsRepresentation(..)
   , Domain
-  , putDomain
-  , getDomain
   , superDomains
   , isSubDomainOf
   , Mailbox
+  , getDomain
+  , putDomain
   , putMailbox
   , getMailbox
   , CanonicalFlag (..)
+  , putCompressedDomain
+  , putCompressedMailbox
   ) where
 
 import qualified Control.Exception as E
@@ -264,39 +266,53 @@ instance IsRepresentation Mailbox String where
 --
 -- ref. https://datatracker.ietf.org/doc/html/rfc4034#section-6.2 - Canonical RR Form
 data CanonicalFlag
-  = Compression   -- ^ Original name with compression
-  | NoCompression -- ^ Original name without compressoin
-  | Canonical     -- ^ Lower name without compressoin
+  = Original  -- ^ Original name without compressoin
+  | Canonical -- ^ Lower name without compressoin
   deriving (Eq, Show)
 
 ----------------------------------------------------------------
 
+-- No name compression for new RRs.
 putDomain :: CanonicalFlag -> Domain -> SPut ()
-putDomain Compression   Domain{..} = putDomain' True  wireLabels
-putDomain NoCompression Domain{..} = putDomain' False wireLabels
-putDomain Canonical     Domain{..} = putDomain' False (reverse canonicalLabels)
+putDomain Original  Domain{..} = do
+    mapM_ putPartialDomain wireLabels
+    put8 0
+putDomain Canonical Domain{..} = do
+    mapM_ putPartialDomain $ reverse canonicalLabels
+    put8 0
 
-putMailbox :: CanonicalFlag -> Mailbox -> SPut ()
-putMailbox cf (Mailbox d) = putDomain cf d
+putPartialDomain :: RawDomain -> SPut ()
+putPartialDomain = putLenShortByteString
 
-putDomain' :: Bool -> [RawDomain] -> SPut ()
-putDomain' _ [] = put8 0
-putDomain' compress dom@(d:ds) = do
+----------------------------------------------------------------
+
+-- Name compression is used only for CNAME, MX, NS, PTR and SOA.
+putCompressedDomain :: Domain -> SPut ()
+putCompressedDomain Domain{..} = putCompress wireLabels
+
+putCompress :: [RawDomain] -> SPut ()
+putCompress [] = put8 0
+putCompress dom@(d:ds) = do
     mpos <- popPointer dom
     cur  <- builderPosition
     case mpos of
-        Just pos | compress -> putPointer pos
-        _                   -> do
+        Just pos -> putPointer pos
+        _        -> do
             -- Pointers are limited to 14-bits!
             when (cur <= 0x3fff) $ pushPointer dom cur
             putPartialDomain d
-            putDomain' compress ds
+            putCompress ds
 
 putPointer :: Int -> SPut ()
 putPointer pos = putInt16 (pos .|. 0xc000)
 
-putPartialDomain :: RawDomain -> SPut ()
-putPartialDomain = putLenShortByteString
+----------------------------------------------------------------
+
+putMailbox :: CanonicalFlag -> Mailbox -> SPut ()
+putMailbox cf (Mailbox d) = putDomain cf d
+
+putCompressedMailbox :: Mailbox -> SPut ()
+putCompressedMailbox (Mailbox d) = putCompressedDomain d
 
 ----------------------------------------------------------------
 

--- a/dnsext-types/DNS/Types/Domain.hs
+++ b/dnsext-types/DNS/Types/Domain.hs
@@ -272,7 +272,7 @@ data CanonicalFlag
 
 ----------------------------------------------------------------
 
--- No name compression for new RRs.
+-- | No name compression for new RRs.
 putDomain :: CanonicalFlag -> Domain -> SPut ()
 putDomain Original  Domain{..} = do
     mapM_ putPartialDomain wireLabels
@@ -308,6 +308,7 @@ putPointer pos = putInt16 (pos .|. 0xc000)
 
 ----------------------------------------------------------------
 
+-- | No name compression for new RRs.
 putMailbox :: CanonicalFlag -> Mailbox -> SPut ()
 putMailbox cf (Mailbox d) = putDomain cf d
 

--- a/dnsext-types/DNS/Types/Encode.hs
+++ b/dnsext-types/DNS/Types/Encode.hs
@@ -35,16 +35,16 @@ encodeQuestion = runSPut . putQuestion
 
 -- | Encode a resource record.
 encodeResourceRecord :: ResourceRecord -> ByteString
-encodeResourceRecord rr = runSPut $ putResourceRecord Compression rr
+encodeResourceRecord rr = runSPut $ putResourceRecord Original rr
 
 -- | Encode a resource data.
 encodeRData :: RData -> ByteString
-encodeRData = runSPut . putRData Compression
+encodeRData = runSPut . putRData Original
 
 -- | Encode a domain with name compression.
 encodeDomain :: Domain -> ByteString
-encodeDomain = runSPut . putDomain Compression
+encodeDomain = runSPut . putCompressedDomain
 
 -- | Encode a mailbox name with name compression.
 encodeMailbox :: Mailbox -> ByteString
-encodeMailbox = runSPut . putMailbox Compression
+encodeMailbox = runSPut . putCompressedMailbox

--- a/dnsext-types/DNS/Types/Message.hs
+++ b/dnsext-types/DNS/Types/Message.hs
@@ -109,7 +109,7 @@ putDNSMessage msg = do
                              , length au
                              , length ad
                              ]
-    putRR = putResourceRecord Compression
+    putRR = putResourceRecord Original
     hm = header msg
     fl = flags hm
     eh = ednsHeader msg
@@ -574,7 +574,7 @@ data Question = Question {
 
 putQuestion :: Question -> SPut ()
 putQuestion Question{..} = do
-    putDomain Compression qname
+    putCompressedDomain qname
     put16 (fromTYPE qtype)
     putCLASS qclass
 
@@ -616,7 +616,10 @@ type AdditionalRecords = [ResourceRecord]
 
 putResourceRecord :: CanonicalFlag -> ResourceRecord -> SPut ()
 putResourceRecord cf ResourceRecord{..} = do
-    putDomain cf rrname
+    if cf == Original then
+        putCompressedDomain rrname
+      else
+        putDomain Canonical rrname
     putTYPE      rrtype
     putCLASS     rrclass
     putSeconds   rrttl

--- a/dnsext-types/DNS/Types/RData.hs
+++ b/dnsext-types/DNS/Types/RData.hs
@@ -294,9 +294,9 @@ data RD_RP = RD_RP {
 
 instance ResourceData RD_RP where
     resourceDataType _ = RP
-    putResourceData _ (RD_RP mbox d) = do
-        putMailbox Canonical mbox
-        putDomain  Canonical d
+    putResourceData cf (RD_RP mbox d) = do
+        putMailbox cf mbox
+        putDomain  cf d
 
 get_rp :: Int -> SGet RD_RP
 get_rp _ = RD_RP <$> getMailbox <*> getDomain
@@ -339,11 +339,11 @@ data RD_SRV = RD_SRV {
 
 instance ResourceData RD_SRV where
     resourceDataType _ = SRV
-    putResourceData _ RD_SRV{..} = do
+    putResourceData cf RD_SRV{..} = do
         put16 srv_priority
         put16 srv_weight
         put16 srv_port
-        putDomain Canonical srv_target
+        putDomain cf srv_target
 
 get_srv :: Int -> SGet RD_SRV
 get_srv _ = RD_SRV <$> get16
@@ -364,7 +364,7 @@ newtype RD_DNAME = RD_DNAME {
 
 instance ResourceData RD_DNAME where
     resourceDataType _ = DNAME
-    putResourceData _ (RD_DNAME d) = putDomain Canonical d
+    putResourceData cf (RD_DNAME d) = putDomain cf d
 
 get_dname :: Int -> SGet RD_DNAME
 get_dname _ = RD_DNAME <$> getDomain

--- a/dnsext-types/test/DecodeSpec.hs
+++ b/dnsext-types/test/DecodeSpec.hs
@@ -45,9 +45,10 @@ test_mx = "f03681800001000100000001036d6577036f726700000f0001c00c000f000100000df
 -- as a pointer to the question domain.
 test_soa :: DNSMessage
 test_soa =
-    let soard = rd_soa "ns1.example.com." "hostmaster@example.com." 0 0 0 0 0
+    let q = [Question "hostmaster.example.com." A classIN]
+        soard = rd_soa "ns1.example.com." "hostmaster@example.com." 0 0 0 0 0
         soarr = ResourceRecord "example.com." SOA 1 3600 soard
-     in defaultResponse { question = [Question "hostmaster.example.com." A classIN]
+     in defaultResponse { question = q
                         , authority = [soarr] }
 
 -- Expected compressed encoding of the 'test_soa' message


### PR DESCRIPTION
`Compression` is misleading because new RRs do not compress domain names at all. And we don't expose `putDomain` with compression feature since extended RRs must not use the name compression. Solution:

- `CanonicalFlag` consists of `Original` and `Canonical`. This improves readability of the encoders.
-  The exported `putDomain` does not compress domain names at at. This prevents misuse of the name compression.
- The internal `putCompressedDomain` is used from `Question`, the target of `ResourceRecord` and rdata of old RRs.

