### PR TITLE
Verify with NSEC3

### DIFF
--- a/dnsext-dnssec/DNS/SEC/Verify/N3SHA.hs
+++ b/dnsext-dnssec/DNS/SEC/Verify/N3SHA.hs
@@ -1,0 +1,22 @@
+module DNS.SEC.Verify.N3SHA (
+    n3sha1
+  ) where
+
+-- memory
+import qualified Data.ByteArray as BA
+
+-- cryptonite
+import Crypto.Hash (HashAlgorithm, hashWith)
+import Crypto.Hash.Algorithms (SHA1(..))
+
+import DNS.SEC.Verify.Types
+
+n3sha1 :: NSEC3Impl
+n3sha1 = shaHelper SHA1
+
+shaHelper :: HashAlgorithm hash => hash -> NSEC3Impl
+shaHelper hash =
+  NSEC3Impl
+  { nsec3IGetHash = hashWith hash
+  , nsec3IGetBytes = BA.convert
+  }

--- a/dnsext-dnssec/DNS/SEC/Verify/NSEC3.hs
+++ b/dnsext-dnssec/DNS/SEC/Verify/NSEC3.hs
@@ -1,0 +1,186 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module DNS.SEC.Verify.NSEC3 where
+
+import Data.String (fromString)
+import Data.ByteString.Short (fromShort)
+
+-- base32
+import qualified Data.ByteString.Base32.Hex as B32Hex
+
+-- dnsext-types
+import DNS.Types hiding (qname)
+import qualified DNS.Types.Opaque as Opaque
+
+-- this package
+import DNS.SEC.Imports
+import DNS.SEC.Types
+import DNS.SEC.Flags ( NSEC3_Flag (OptOut) )
+import DNS.SEC.Verify.Types
+
+
+{- find NSEC3 records which covers or matches with qname or super names of qname,
+   to recognize non-existence of domain or non-existence of RRset -}
+verify :: [(NSEC3_Range, Domain -> Opaque)] -> Domain -> TYPE -> Either String NSEC3_Result
+verify n3s domain qtype = n3RangeRefines n3s >>= findEncloser
+  where
+    findEncloser refines =
+      maybe (Left "NSEC3.verify: no NSEC3 encloser") id $
+      getNoData props
+      <|>
+      {- find non-existence of RRset -}
+      loop stepNE ppairs
+      <|>
+      {- find wildcard-expansion result -}
+      loop stepWE props
+      where
+        {- reuse computed range-props for closest-name and next-closer-name -}
+        ppairs = zip props (tail props)
+        props = map rangePropSet $ superDomains domain ++ [fromString "."]
+
+        {- return first result or continue -}
+        loop :: (a -> Maybe b)
+             -> [a] -> Maybe b
+        loop step = foldr stepK Nothing
+          where
+            -- stepK :: a -> Maybe b -> Maybe b
+            stepK p k = step p <|> k
+
+        getNoData :: [[RangeProp]] -> Maybe (Either String NSEC3_Result)
+        getNoData []           =  Nothing
+        getNoData (exists:_)   =  notElemBitmap <$> just1 (matches exists)
+          where
+            notElemBitmap m@( Matches ((_, RD_NSEC3 {..}), _) )
+              | qtype `elem` nsec3_types  =  Left $ "NSEC3.verify: NoData: type bitmap has query type `" ++ show qtype ++ "`."
+              | otherwise                 =  Right $ n3r_noData m
+
+        {- next-closer-name 'cover' for qname and closest-name 'match' for super-name are checked at the same time -}
+        stepNE :: ([RangeProp], [RangeProp]) -> Maybe (Either String NSEC3_Result)
+        stepNE (nexts, closests) = do
+          nextCloser@(Covers ((_, nextN3), _))  <- just1 $ covers nexts
+          closest@(Matches (_, cn))             <- just1 $ matches closests
+
+          let wildcardProps = rangePropSet (fromString "*" <> cn)
+              takeWildcardCover    = just1 $ covers wildcardProps
+              takeWildcardMatches  = just1 $ matches wildcardProps
+              takeWildcardNoData   = notElemBitmap <$> takeWildcardMatches
+                where
+                  notElemBitmap m@( Matches ((_, RD_NSEC3 {..}), _) )
+                    | qtype `elem` nsec3_types  =  Left $ "NSEC3.verify: WildcardNoData: type bitmap has query type `" ++ show qtype ++ "`."
+                    | otherwise                 =  Right $ n3r_wildcardNoData closest nextCloser m
+              optOutDelegation
+                | OptOut `elem` nsec3_flags nextN3  =  Right $ n3r_optOutDelegation closest nextCloser
+                | otherwise                         =  Left $ "NSEC3.verify: wildcard name is not matched or covered."
+          ( Right . n3r_nameError closest nextCloser <$> takeWildcardCover  <|>
+            takeWildcardNoData                                              <|>
+            pure optOutDelegation )
+
+        stepWE :: [RangeProp] -> Maybe (Either String NSEC3_Result)
+        stepWE nexts = Right . n3r_wildcardExpansion <$> just1 (covers nexts)
+
+        rangePropSet :: Domain -> [RangeProp]
+        rangePropSet qname =
+          [ r
+          | refine <- refines
+          , Just r <- [refine qname]
+          ]
+
+        matches xs = [ x | M x <- xs ]
+        covers  xs = [ x | C x <- xs ]
+        just1 xs = case xs of
+          []   ->  Nothing
+          [x]  ->  Just x
+          _    ->  Nothing
+
+newtype Matches a = Matches a  deriving Show
+newtype Covers a  = Covers a   deriving Show
+
+n3r_nameError :: Matches NSEC3_Witness -> Covers NSEC3_Witness -> Covers NSEC3_Witness -> NSEC3_Result
+n3r_nameError (Matches closest) (Covers next) (Covers wildcard) =
+  N3Result_NameError closest next wildcard
+
+n3r_noData :: Matches NSEC3_Witness -> NSEC3_Result
+n3r_noData (Matches closest) =
+  N3Result_NoData closest
+
+n3r_optOutDelegation :: Matches NSEC3_Witness -> Covers NSEC3_Witness -> NSEC3_Result
+n3r_optOutDelegation (Matches closest) (Covers next) =
+  N3Result_OptOutDelegation closest next
+
+n3r_wildcardExpansion :: Covers NSEC3_Witness -> NSEC3_Result
+n3r_wildcardExpansion (Covers next) =
+  N3Result_WildcardExpansion next
+
+n3r_wildcardNoData :: Matches NSEC3_Witness -> Covers NSEC3_Witness -> Matches NSEC3_Witness -> NSEC3_Result
+n3r_wildcardNoData (Matches closest) (Covers next) (Matches wildcard) =
+  N3Result_WildcardNoData closest next wildcard
+
+type RangeProp = RangeProp_ NSEC3_Witness
+
+---
+
+data RangeProp_ a
+  = M (Matches a)
+  | C (Covers  a)
+  deriving Show
+
+n3Covers :: Ord a => a -> a -> a -> Bool
+n3Covers lower upper qv = lower < qv && qv < upper
+
+n3CoversR :: Ord a => a -> a -> a -> Bool
+n3CoversR lower upper qv = qv < upper || lower < qv
+  {- https://datatracker.ietf.org/doc/html/rfc5155#section-3.1.7
+     "The value of the Next Hashed Owner Name
+      field in the last NSEC3 RR in the zone is the same as the hashed
+      owner name of the first NSEC3 RR in the zone in hash order." -}
+
+{- get funcs to compute 'match' or 'cover' with ranges from NSEC3 record-set -}
+n3RangeRefines :: [(NSEC3_Range, Domain -> Opaque)] -> Either String [(Domain -> Maybe (RangeProp_ NSEC3_Witness))]
+n3RangeRefines ranges0 = do
+  (((owner1,_),_), _)  <- maybe (Left "NSEC3.n3RangeRefines: no NSEC3 records") Right $ uncons ranges0
+  (_, zname)           <- maybe (Left "NSEC3.n3RangeRefines: no zone name")     Right $ unconsName owner1
+
+  let rs = [ (ownerBytes, r)
+           | r@((rrn, RD_NSEC3 {..}), _) <- ranges0
+           , nsec3_flags `elem` [ [], [OptOut] ]
+           {- https://datatracker.ietf.org/doc/html/rfc5155#section-8.2
+              "A validator MUST ignore NSEC3 RRs with a Flag fields value other than zero or one." -}
+           , Just (owner32h, parent) <- [ unconsName rrn ]
+           , parent == zname
+           , ownerBytes <- decodeBase32 owner32h
+           ]
+  takeRefines rs
+
+  where
+    unconsName :: Domain -> Maybe (ShortByteString, Domain)
+    unconsName name = case toWireLabels name of
+      x:xs ->  Just (x, fromWireLabels xs)
+      []   ->  Nothing
+
+    decodeBase32 :: ShortByteString -> [Opaque]
+    decodeBase32 part = either (const []) ((: []) . Opaque.fromByteString) $ B32Hex.decodeBase32 $ fromShort part
+
+    takeRefines :: [(Opaque, (NSEC3_Range, Domain -> Opaque))] -> Either String [(Domain -> Maybe (RangeProp_ NSEC3_Witness))]
+    takeRefines ranges
+      | length (filter fst results) > 1  =  Left "NSEC3.n3RangeRefines: multiple rounded records found."
+      | otherwise                        =  Right $ map snd results
+      where
+        results =
+          [ (rounded, result)
+          | (owner, (rangeB32H@(_, RD_NSEC3 {..}), hash)) <- ranges
+          , let next = nsec3_next_hashed_owner_name  {- binary hashed value, not base32hex -}
+                rounded = owner > next
+                refineWithRange cover qname
+                  {- owner and next are decoded range, not base32hex -}
+                  | hq == owner          =  Just $ M $ Matches (rangeB32H, qname)
+                  | cover owner next hq  =  Just $ C $ Covers  (rangeB32H, qname)
+                  | otherwise            =  Nothing
+                  where hq = hash qname
+                result
+                  | rounded    =  refineWithRange n3CoversR
+                  | otherwise  =  refineWithRange n3Covers
+                  {- base32hex does not change hash ordering. https://datatracker.ietf.org/doc/html/rfc5155#section-1.3
+                     "Terminology: Hash order:
+                      Note that this order is the same as the canonical DNS name order specified in [RFC4034],
+                      when the hashed owner names are in base32, encoded with an Extended Hex Alphabet [RFC4648]." -}
+          ]

--- a/dnsext-dnssec/DNS/SEC/Verify/Types.hs
+++ b/dnsext-dnssec/DNS/SEC/Verify/Types.hs
@@ -8,6 +8,7 @@ import DNS.Types
 -- this package
 import DNS.SEC.Imports
 import DNS.SEC.PubKey
+import DNS.SEC.Types (RD_NSEC3)
 
 data RRSIGImpl =
   forall pubkey sig .
@@ -23,3 +24,44 @@ data DSImpl =
   { dsIGetDigest :: ByteString -> digest
   , dsIVerify :: digest -> ByteString -> Bool
   }
+
+data NSEC3Impl =
+  forall hash .
+  NSEC3Impl
+  { nsec3IGetHash :: ByteString -> hash
+  , nsec3IGetBytes :: hash -> ByteString
+  }
+
+{- | owner name and NSEC3 rdata express hashed domain-name range -}
+type NSEC3_Range = (Domain, RD_NSEC3)
+
+{- | range and qname which is owner of it or covered by it -}
+type NSEC3_Witness = (NSEC3_Range, Domain)
+
+{- | verify result of NSEC3 -}
+data NSEC3_Result
+  = N3Result_NameError
+    { nsec3_closest_match     :: NSEC3_Witness
+    , nsec3_next_closer_cover :: NSEC3_Witness
+    , nsec3_wildcard_cover    :: NSEC3_Witness
+    }
+    {- https://datatracker.ietf.org/doc/html/rfc5155#appendix-B.1 -}
+  | N3Result_NoData
+    { nsec3_closest_match     :: NSEC3_Witness }
+    {- https://datatracker.ietf.org/doc/html/rfc5155#appendix-B.2
+       https://datatracker.ietf.org/doc/html/rfc5155#appendix-B.6 -}
+  | N3Result_OptOutDelegation
+    { nsec3_closest_match     :: NSEC3_Witness
+    , nsec3_next_closer_cover :: NSEC3_Witness
+    }
+    {- https://datatracker.ietf.org/doc/html/rfc5155#appendix-B.3 -}
+  | N3Result_WildcardExpansion
+    { nsec3_next_closer_cover :: NSEC3_Witness }
+    {- https://datatracker.ietf.org/doc/html/rfc5155#appendix-B.4 -}
+  | N3Result_WildcardNoData
+    { nsec3_closest_match     :: NSEC3_Witness
+    , nsec3_next_closer_cover :: NSEC3_Witness
+    , nsec3_wildcard_match    :: NSEC3_Witness
+    }
+    {- https://datatracker.ietf.org/doc/html/rfc5155#appendix-B.5 -}
+  deriving Show

--- a/dnsext-dnssec/dnsext-dnssec.cabal
+++ b/dnsext-dnssec/dnsext-dnssec.cabal
@@ -84,6 +84,7 @@ test-suite spec
         base,
         bytestring,
         hspec,
+        base32,
         memory,
         iproute >=1.3.2,
         word8

--- a/dnsext-dnssec/dnsext-dnssec.cabal
+++ b/dnsext-dnssec/dnsext-dnssec.cabal
@@ -45,6 +45,7 @@ library
         dnsext-types,
         bytestring,
         containers,
+        base32,
         memory,
         cryptonite,
         iproute >=1.3.2,

--- a/dnsext-dnssec/dnsext-dnssec.cabal
+++ b/dnsext-dnssec/dnsext-dnssec.cabal
@@ -33,6 +33,8 @@ library
         DNS.SEC.Verify.ECDSA
         DNS.SEC.Verify.EdDSA
         DNS.SEC.Verify.RSA
+        DNS.SEC.Verify.N3SHA
+        DNS.SEC.Verify.NSEC3
         DNS.SEC.Verify.Types
         DNS.SEC.Verify.Verify
 

--- a/dnsext-dnssec/test/VerifySpec.hs
+++ b/dnsext-dnssec/test/VerifySpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module VerifySpec (spec) where
 
@@ -10,6 +11,7 @@ import Data.Int
 import Data.Word
 import Data.ByteString (ByteString)
 
+import Data.ByteString.Base32.Hex (decodeBase32)
 import Data.ByteArray.Encoding (Base (Base16, Base64), convertFromBase)
 
 import DNS.Types
@@ -33,6 +35,17 @@ spec = do
     it "ECDSA/P384" $ caseRRSIG ecdsaP384
     it "Ed25519"    $ caseRRSIG ed25519
     it "Ed448"      $ caseRRSIG ed448
+  describe "NSEC3 hash" $ do
+    it "RFC7129 section5" $ caseNSEC3Hash nsec3HashRFC7129
+  describe "verify NSEC3" $ do
+    it "NameError 1" $ caseNSEC3 nsec3RFC7129NameError
+    it "NameError 2" $ caseNSEC3 nsec3RFC5155NameError
+    it "NoData 1" $ caseNSEC3 nsec3RFC5155NoData1
+    it "NoData 2" $ caseNSEC3 nsec3RFC5155NoData2
+    it "NoData 3" $ caseNSEC3 nsec3RFC5155NoData3
+    it "opt-out delegation" $ caseNSEC3 nsec3RFC5155OptOut
+    it "wildcard expansion" $ caseNSEC3 nsec3RFC5155WildcardExpansion
+    it "wildcard NoData" $ caseNSEC3 nsec3RFC5155WildcardNoData
 
 -----
 -- KeyTag cases
@@ -232,6 +245,195 @@ ed448 =
              \ SOIOKBGzG+yWYtz1/jjbzl5GGkWvREUCUA "
 
 -----
+-- NSEC3 hash cases
+
+type NSEC3Hash_CASE = ((RData, Domain), String)
+
+caseNSEC3Hash :: NSEC3Hash_CASE -> Expectation
+caseNSEC3Hash ((rd, domain), expectB32H) = either expectationFailure (const $ pure ()) $ do
+  nsec3 <- maybe (Left $ "caseNSEC3Hash: not NSEC3: " ++ show rd) Right $ fromRData rd
+  computed <- hashNSEC3 nsec3 domain
+  check computed
+  where
+    expect = opaqueFromB32Hex expectB32H
+    check computed
+      | computed == expect  =  Right ()
+      | otherwise           =  Left $ show computed ++ " =/= " ++ show expect
+
+-- example from https://datatracker.ietf.org/doc/html/rfc7129#section-5
+nsec3HashRFC7129 :: NSEC3Hash_CASE
+nsec3HashRFC7129 =
+  ( ( rd_nsec3' 1 0 2 "DEAD" "1AVVQN74SG75UKFVF25DGCETHGQ638EK" [NS, SOA, RRSIG, DNSKEY, NSEC3PARAM]
+    , "example.org."
+    )
+  , "15bg9l6359f5ch23e34ddua6n1rihl9h"
+  )
+
+-----
+-- NSEC3 cases
+
+type NSEC3_ExpectW = (Domain, Domain) {- expect owner and qname -}
+data NSEC3_Expect
+  = N3W_NameError NSEC3_ExpectW NSEC3_ExpectW NSEC3_ExpectW
+  | N3W_NoData NSEC3_ExpectW
+  | N3W_OptOutDelegation NSEC3_ExpectW NSEC3_ExpectW
+  | N3W_WildcardExpansion NSEC3_ExpectW
+  | N3W_WildcardNoData NSEC3_ExpectW NSEC3_ExpectW NSEC3_ExpectW
+  deriving (Eq, Show)
+type NSEC3_CASE = (([(Domain, RData)], Domain, TYPE), NSEC3_Expect)
+
+nsec3CheckResult :: NSEC3_Result -> NSEC3_Expect -> Either String ()
+nsec3CheckResult result expect = case (result, expect) of
+  (N3Result_NameError {..}, N3W_NameError ec en ew)               -> do
+    check "name-error: closest"         (w2e nsec3_closest_match) ec
+    check "name-error: next"            (w2e nsec3_next_closer_cover) en
+    check "name-error: wildcard"        (w2e nsec3_wildcard_cover) ew
+  (N3Result_NoData {..},    N3W_NoData ec)                        -> do
+    check "no-data: closest"            (w2e nsec3_closest_match) ec
+  (N3Result_OptOutDelegation {..}, N3W_OptOutDelegation ec en)    -> do
+    check "opt-out: closest"            (w2e nsec3_closest_match) ec
+    check "opt-out: next"               (w2e nsec3_next_closer_cover) en
+  (N3Result_WildcardExpansion {..}, N3W_WildcardExpansion en)     -> do
+    check "wildcard-expansion: next"    (w2e nsec3_next_closer_cover) en
+  (N3Result_WildcardNoData {..},    N3W_WildcardNoData ec en ew)  -> do
+    check "wildcard-no-data: closest"   (w2e nsec3_closest_match) ec
+    check "wildcard-no-data: next"      (w2e nsec3_next_closer_cover) en
+    check "wildcard-no-data: wildcard"  (w2e nsec3_wildcard_match) ew
+  _                                                               ->
+    Left $ unlines ["result data mismatch:", show result, show expect]
+
+  where
+    w2e :: NSEC3_Witness -> NSEC3_ExpectW
+    w2e ((owner, _range), qname) = (owner, qname)
+    check tag r e
+      | r == e     =  Right ()
+      | otherwise  =  Left $ tag ++ ": " ++ show r ++ " =/= " ++ show e
+
+caseNSEC3 :: NSEC3_CASE -> Expectation
+caseNSEC3 ((rds, qn, qtype), expect) = either expectationFailure (const $ pure ()) $ do
+  result <- verifyNSEC3 ranges qn qtype
+  nsec3CheckResult result expect
+  where
+    ranges = [ (owner, nsec3) | (owner, rd) <- rds, Just nsec3 <- [fromRData rd] ]
+
+-- example from https://datatracker.ietf.org/doc/html/rfc7129#section-5.5
+nsec3RFC7129NameError :: NSEC3_CASE
+nsec3RFC7129NameError = ((rdatas, fromString "x.2.example.org.", TXT), expect)
+  where
+    rdatas =
+      [ ("15bg9l6359f5ch23e34ddua6n1rihl9h.example.org.",
+         rd_nsec3' 1 0 2 "DEAD" "1AVVQN74SG75UKFVF25DGCETHGQ638EK" [NS, SOA, RRSIG, DNSKEY, NSEC3PARAM])
+      , ("1avvqn74sg75ukfvf25dgcethgq638ek.example.org.",
+         rd_nsec3' 1 0 2 "DEAD" "75B9ID679QQOV6LDFHD8OCSHSSSB6JVQ" [])
+      , ("75b9id679qqov6ldfhd8ocshsssb6jvq.example.org.",
+         rd_nsec3' 1 0 2 "DEAD" "8555T7QEGAU7PJTKSNBCHG4TD2M0JNPJ" [TXT, RRSIG])
+      ]
+    expect =
+      N3W_NameError
+      ("15bg9l6359f5ch23e34ddua6n1rihl9h.example.org.", "example.org.")
+      ("75b9id679qqov6ldfhd8ocshsssb6jvq.example.org.", "2.example.org.")
+      ("1avvqn74sg75ukfvf25dgcethgq638ek.example.org.", "*.example.org.")
+
+-- example from https://datatracker.ietf.org/doc/html/rfc5155#appendix-B.1
+-- Name Error
+nsec3RFC5155NameError :: NSEC3_CASE
+nsec3RFC5155NameError = ((rdatas, "a.c.x.w.example.", A), expect)
+  where
+    rdatas =
+      [ ("0p9mhaveqvm6t7vbl5lop2u3t2rp3tom.example.",
+         rd_nsec3' 1 1 12 "aabbccdd" "2t7b4g4vsa5smi47k61mv5bv1a22bojr" [MX, DNSKEY, NS, SOA, NSEC3PARAM, RRSIG])
+      , ("b4um86eghhds6nea196smvmlo4ors995.example.",
+         rd_nsec3' 1 1 12 "aabbccdd" "gjeqe526plbf1g8mklp59enfd789njgi" [MX, RRSIG])
+      , ("35mthgpgcu1qg68fab165klnsnk3dpvl.example.",
+         rd_nsec3' 1 1 12 "aabbccdd" "b4um86eghhds6nea196smvmlo4ors995" [NS, DS, RRSIG])
+      ]
+    expect =
+      N3W_NameError
+      ("b4um86eghhds6nea196smvmlo4ors995.example.", "x.w.example.")
+      ("0p9mhaveqvm6t7vbl5lop2u3t2rp3tom.example.", "c.x.w.example.")
+      ("35mthgpgcu1qg68fab165klnsnk3dpvl.example.", "*.x.w.example")
+
+-- example from https://datatracker.ietf.org/doc/html/rfc5155#appendix-B.2
+-- No Data Error
+nsec3RFC5155NoData1 :: NSEC3_CASE
+nsec3RFC5155NoData1 = ((rdatas, "ns1.example.", MX), expect)
+  where
+    rdatas =
+      [ ("2t7b4g4vsa5smi47k61mv5bv1a22bojr.example.",
+         rd_nsec3' 1 1 12 "aabbccdd" "2vptu5timamqttgl4luu9kg21e0aor3s" [A, RRSIG])
+      ]
+    expect = N3W_NoData ("2t7b4g4vsa5smi47k61mv5bv1a22bojr.example.", "ns1.example.")
+
+-- example from https://datatracker.ietf.org/doc/html/rfc5155#appendix-B.2.1
+-- No Data Error, Empty Non-Terminal
+nsec3RFC5155NoData2 :: NSEC3_CASE
+nsec3RFC5155NoData2 = ((rdatas, "y.w.example.", A), expect)
+  where
+    rdatas =
+      [ ("ji6neoaepv8b5o6k4ev33abha8ht9fgc.example.",
+        rd_nsec3' 1 1 12 "aabbccdd" "k8udemvp1j2f7eg6jebps17vp3n8i58h" [])
+      ]
+    expect = N3W_NoData ("ji6neoaepv8b5o6k4ev33abha8ht9fgc.example.", "y.w.example.")
+
+-- example from https://datatracker.ietf.org/doc/html/rfc5155#appendix-B.6
+-- DS Child Zone No Data Error
+nsec3RFC5155NoData3 :: NSEC3_CASE
+nsec3RFC5155NoData3 = ((rdatas, "example.", DS), expect)
+  where
+    rdatas =
+      [ ("0p9mhaveqvm6t7vbl5lop2u3t2rp3tom.example.",
+         rd_nsec3' 1 1 12 "aabbccdd" "2t7b4g4vsa5smi47k61mv5bv1a22bojr" [MX, DNSKEY, NS])
+      ]
+    expect = N3W_NoData ("0p9mhaveqvm6t7vbl5lop2u3t2rp3tom.example.", "example.")
+
+-- example from https://datatracker.ietf.org/doc/html/rfc5155#appendix-B.3
+-- Referral to an Opt-Out Unsigned Zone
+nsec3RFC5155OptOut :: NSEC3_CASE
+nsec3RFC5155OptOut = ((rdatas, "mc.c.example.", MX), expect)
+  where
+    rdatas =
+      [ ("35mthgpgcu1qg68fab165klnsnk3dpvl.example.",
+         rd_nsec3' 1 1 12 "aabbccdd" "b4um86eghhds6nea196smvmlo4ors995" [NS, DS, RRSIG])
+      , ("0p9mhaveqvm6t7vbl5lop2u3t2rp3tom.example.",
+         rd_nsec3' 1 1 12 "aabbccdd" "2t7b4g4vsa5smi47k61mv5bv1a22bojr" [MX, DNSKEY, NS, SOA, NSEC3PARAM, RRSIG])
+      ]
+    expect =
+      N3W_OptOutDelegation
+      ("0p9mhaveqvm6t7vbl5lop2u3t2rp3tom.example.", "example.")
+      ("35mthgpgcu1qg68fab165klnsnk3dpvl.example.", "c.example.")
+
+-- example from https://datatracker.ietf.org/doc/html/rfc5155#appendix-B.4
+-- Wildcard Expansion
+nsec3RFC5155WildcardExpansion :: NSEC3_CASE
+nsec3RFC5155WildcardExpansion = ((rdatas, "a.z.w.example.", MX), expect)
+  where
+    rdatas =
+      [ ("q04jkcevqvmu85r014c7dkba38o0ji5r.example.",
+         rd_nsec3' 1 1 12 "aabbccdd" "r53bq7cc2uvmubfu5ocmm6pers9tk9en" [A, RRSIG])
+      ]
+    expect = N3W_WildcardExpansion ("q04jkcevqvmu85r014c7dkba38o0ji5r.example.", "z.w.example.")
+
+
+-- example from https://datatracker.ietf.org/doc/html/rfc5155#appendix-B.5
+-- Wildcard No Data Error
+nsec3RFC5155WildcardNoData :: NSEC3_CASE
+nsec3RFC5155WildcardNoData = ((rdatas, "a.z.w.example.", AAAA), expect)
+  where
+    rdatas =
+      [ ("k8udemvp1j2f7eg6jebps17vp3n8i58h.example.",
+         rd_nsec3' 1 1 12 "aabbccdd" "kohar7mbb8dc2ce8a9qvl8hon4k53uhi" [])
+      , ("q04jkcevqvmu85r014c7dkba38o0ji5r.example.",
+         rd_nsec3' 1 1 12 "aabbccdd" "r53bq7cc2uvmubfu5ocmm6pers9tk9en" [A, RRSIG])
+      , ("r53bq7cc2uvmubfu5ocmm6pers9tk9en.example.",
+         rd_nsec3' 1 1 12 "aabbccdd" "t644ebqk9bibcna874givr6joj62mlhv" [MX, RRSIG])
+      ]
+    expect =
+      N3W_WildcardNoData
+      ("k8udemvp1j2f7eg6jebps17vp3n8i58h.example.", "w.example.")
+      ("q04jkcevqvmu85r014c7dkba38o0ji5r.example.", "z.w.example.")
+      ("r53bq7cc2uvmubfu5ocmm6pers9tk9en.example.", "*.w.example")
+
+-----
 -- helpers
 
 rd_dnskey' :: Word16 -> Word8 -> Word8 -> String -> RData
@@ -245,10 +447,18 @@ rd_ds' keytag pubalg digalg digest = rd_ds keytag (toPubAlg pubalg) (toDigestAlg
 rd_rrsig' :: TYPE -> Word8 -> Word8 -> TTL -> Int64 -> Int64 -> Word16 -> String -> String -> RData
 rd_rrsig' typ alg a b c d e dom = rd_rrsig typ (toPubAlg alg) a b c d e (fromString dom) . opaqueFromB64
 
+rd_nsec3' :: Word8 -> Word8 -> Word16 -> String -> String -> [TYPE] -> RData
+rd_nsec3' alg fs i salt next = rd_nsec3 (toHashAlg alg) (toNSEC3flags fs) i (opaqueFromB16Hex salt) (opaqueFromB32Hex next)
+
 opaqueFromB16Hex :: String -> Opaque
 opaqueFromB16Hex =
   either (error "opaqueFromB16Hex: fail to decode hex") Opaque.fromByteString .
   convertFromBase Base16 . (fromString :: String -> ByteString) . filter (/= ' ')
+
+opaqueFromB32Hex :: String -> Opaque
+opaqueFromB32Hex =
+  either (error "opaqueFromB32Hex: fail to decode base32hex") Opaque.fromByteString .
+  decodeBase32 . (fromString :: String -> ByteString) . filter (/= ' ')
 
 opaqueFromB64 :: String -> Opaque
 opaqueFromB64 =


### PR DESCRIPTION
Add logic to prove empty RRset or non-existence of RRset with NSEC3 records.

This logic recognizes the following cases where NSEC3 records would be returned:

* Name Error - domain name does not exist
* No Data - domain name exists, but RRset is empty for specified type
* Delegate not signed domain name with OptOut flag
* Wildcard Expansion - domain name matches wildcard, but not wildcard name does not exist
* Wildcard No Data - domain name matches wildcard, but RRest is empty for specified type
