### PR TITLE
export low-level baseXX encoder and decoder from dnsext-types

### DIFF
--- a/dnsext-types/DNS/Types/Base32Hex.hs
+++ b/dnsext-types/DNS/Types/Base32Hex.hs
@@ -59,7 +59,11 @@ encode bs =
 
 decode :: ByteString -> Either String ByteString
 decode bs = do
-  let len = (5 * BS.length bs) `div` 8
+  let ilen = BS.length bs
+      len = (5 * ilen) `div` 8
+      r = ilen `mod` 8
+  when (r `notElem` [0, 2, 4, 5, 7]) $
+    Left $ "Base32Hex.decode: invalid length of base32hex: " ++ show ilen
   cs <- fmap chunks8 . mapM fromHex32 $ BS.unpack bs
   return $ BS.pack $ A.elems $ A.runSTUArray $ do
     a <- A.newArray (0 :: Int, len-1) 0

--- a/dnsext-types/DNS/Types/Base32Hex.hs
+++ b/dnsext-types/DNS/Types/Base32Hex.hs
@@ -81,11 +81,11 @@ decode bs = do
     store8 a i v = A.writeArray a i v
 
     stores ss a n f0 f1 f2 f3 f4 f5 f6 f7 = do
-      let w0 = f0 `shiftL` 3 .|. f1 `shiftR` 2
-          w1 = f1 `shiftL` 6 .|. f2 `shiftL` 1 .|. f3 `shiftR` 4
-          w2 = f3 `shiftL` 4 .|. f4 `shiftR` 1
-          w3 = f4 `shiftL` 7 .|. f5 `shiftL` 2 .|. f6 `shiftR` 3
-          w4 = f6 `shiftL` 5 .|. f7
+      let w0 = f0 `unsafeShiftL` 3 .|. f1 `unsafeShiftR` 2
+          w1 = f1 `unsafeShiftL` 6 .|. f2 `unsafeShiftL` 1 .|. f3 `unsafeShiftR` 4
+          w2 = f3 `unsafeShiftL` 4 .|. f4 `unsafeShiftR` 1
+          w3 = f4 `unsafeShiftL` 7 .|. f5 `unsafeShiftL` 2 .|. f6 `unsafeShiftR` 3
+          w4 = f6 `unsafeShiftL` 5 .|. f7
       sequence_ $
         take ss
         [ store8 a  n      w0,

--- a/dnsext-types/DNS/Types/Base32Hex.hs
+++ b/dnsext-types/DNS/Types/Base32Hex.hs
@@ -13,6 +13,7 @@ import Control.Monad
 import Data.Bits
 import Data.ByteString (ByteString)
 import qualified Data.List as L
+import Data.Word8 (_0, _9, _A, _V, _a, _v)
 
 -- | Encode ByteString using the
 -- <https://tools.ietf.org/html/rfc4648#section-7 RFC4648 base32hex>
@@ -65,12 +66,9 @@ decode bs = do
     go cs a 0
   where
     fromHex32 w
-      {- '0' <= w <= '9' -}
-      | 48 <= w && w <= 57   =  Right $ w - 48
-      {- 'A' <= w <= 'V' -}
-      | 65 <= w && w <= 86   =  Right $ w - 55
-      {- 'a' <= w <= 'v' -}
-      | 97 <= w && w <= 118  =  Right $ w - 87
+      | _0 <= w && w <= _9   =  Right $ w - 48
+      | _A <= w && w <= _V   =  Right $ w - 55
+      | _a <= w && w <= _v   =  Right $ w - 87
       | otherwise            =  Left "Base32Hex.decode: not base32hex format"
 
     chunks8 = L.unfoldr chunk

--- a/dnsext-types/DNS/Types/Base32Hex.hs
+++ b/dnsext-types/DNS/Types/Base32Hex.hs
@@ -1,4 +1,7 @@
-module DNS.Types.Base32Hex (encode) where
+module DNS.Types.Base32Hex (
+    encode
+  , decode
+  ) where
 
 import qualified Data.Array.MArray as A
 import qualified Data.Array.IArray as A
@@ -9,6 +12,7 @@ import qualified Data.ByteString   as BS
 import Control.Monad
 import Data.Bits
 import Data.ByteString (ByteString)
+import qualified Data.List as L
 
 -- | Encode ByteString using the
 -- <https://tools.ietf.org/html/rfc4648#section-7 RFC4648 base32hex>
@@ -51,3 +55,82 @@ encode bs =
         when (r > 2) $ store8 a (q+2) wr
         go ws a $ n + 8
 {-# INLINE encode #-}
+
+decode :: ByteString -> Either String ByteString
+decode bs = do
+  let len = (5 * BS.length bs) `div` 8
+  cs <- fmap chunks8 . mapM fromHex32 $ BS.unpack bs
+  return $ BS.pack $ A.elems $ A.runSTUArray $ do
+    a <- A.newArray (0 :: Int, len-1) 0
+    go cs a 0
+  where
+    fromHex32 w
+      {- '0' <= w <= '9' -}
+      | 48 <= w && w <= 57   =  Right $ w - 48
+      {- 'A' <= w <= 'V' -}
+      | 65 <= w && w <= 86   =  Right $ w - 55
+      {- 'a' <= w <= 'v' -}
+      | 97 <= w && w <= 118  =  Right $ w - 87
+      | otherwise            =  Left "Base32Hex.decode: not base32hex format"
+
+    chunks8 = L.unfoldr chunk
+      where
+        chunk s
+          | null hd    =  Nothing
+          | otherwise  =  Just (hd, tl)
+          where (hd, tl) = splitAt 8 s
+
+    store8 a i v = A.writeArray a i v
+
+    stores ss a n f0 f1 f2 f3 f4 f5 f6 f7 = do
+      let w0 = f0 `shiftL` 3 .|. f1 `shiftR` 2
+          w1 = f1 `shiftL` 6 .|. f2 `shiftL` 1 .|. f3 `shiftR` 4
+          w2 = f3 `shiftL` 4 .|. f4 `shiftR` 1
+          w3 = f4 `shiftL` 7 .|. f5 `shiftL` 2 .|. f6 `shiftR` 3
+          w4 = f6 `shiftL` 5 .|. f7
+      sequence_ $
+        take ss
+        [ store8 a  n      w0,
+          store8 a (n + 1) w1,
+          store8 a (n + 2) w2,
+          store8 a (n + 3) w3,
+          store8 a (n + 4) w4 ]
+
+    go [] a _n =  return a
+    go ([f0,f1]:[]) a n = do
+      stores 1 a n f0 f1 0 0 0 0 0 0
+      -- let w0 = f0 `shiftL` 3 .|. f1 `shiftR` 2
+      return a
+
+    go ([f0,f1,f2,f3]:[]) a n = do
+      stores 2 a n f0 f1 f2 f3 0 0 0 0
+      -- let w0 = f0 `shiftL` 3 .|. f1 `shiftR` 2
+      --     w1 = f1 `shiftL` 6 .|. f2 `shiftL` 1 .|. f3 `shiftR` 4
+      return a
+
+    go ([f0,f1,f2,f3,f4]:[]) a n = do
+      stores 3 a n f0 f1 f2 f3 f4 0 0 0
+      -- let w0 = f0 `shiftL` 3 .|. f1 `shiftR` 2
+      --     w1 = f1 `shiftL` 6 .|. f2 `shiftL` 1 .|. f3 `shiftR` 4
+      --     w2 = f3 `shiftL` 4 .|. f4 `shiftR` 1
+      return a
+
+    go ([f0,f1,f2,f3,f4,f5,f6]:[]) a n = do
+      stores 4 a n f0 f1 f2 f3 f4 f5 f6 0
+      -- let w0 = f0 `shiftL` 3 .|. f1 `shiftR` 2
+      --     w1 = f1 `shiftL` 6 .|. f2 `shiftL` 1 .|. f3 `shiftR` 4
+      --     w2 = f3 `shiftL` 4 .|. f4 `shiftR` 1
+      --     w3 = f4 `shiftL` 7 .|. f5 `shiftL` 2 .|. f6 `shiftR` 3
+      return a
+
+    go ([f0,f1,f2,f3,f4,f5,f6,f7]:cs) a n = do
+      stores 5 a n f0 f1 f2 f3 f4 f5 f6 f7
+      -- let w0 = f0 `shiftL` 3 .|. f1 `shiftR` 2
+      --     w1 = f1 `shiftL` 6 .|. f2 `shiftL` 1 .|. f3 `shiftR` 4
+      --     w2 = f3 `shiftL` 4 .|. f4 `shiftR` 1
+      --     w3 = f4 `shiftL` 7 .|. f5 `shiftL` 2 .|. f6 `shiftR` 3
+      --     w4 = f6 `shiftL` 5 .|. f7
+      go cs a (n + 5)
+
+    go _ _ _ = error "Base32Hex.decode: internal error. invalid chunk"
+{-# INLINE decode #-}

--- a/dnsext-types/DNS/Types/EDNS.hs
+++ b/dnsext-types/DNS/Types/EDNS.hs
@@ -252,7 +252,7 @@ data OD_ClientSubnet =
 instance Show OD_ClientSubnet where
     show (OD_ClientSubnet b1 b2 ip@(IPv4 _)) = _showECS 1 b1 b2 $ show ip
     show (OD_ClientSubnet b1 b2 ip@(IPv6 _)) = _showECS 2 b1 b2 $ show ip
-    show (OD_ECSgeneric fam b1 b2 a) = _showECS fam b1 b2 $ b16encode $ Opaque.toByteString a
+    show (OD_ECSgeneric fam b1 b2 a) = _showECS fam b1 b2 $ C8.unpack $ Opaque.toBase16 a
 
 instance OptData OD_ClientSubnet where
     optDataCode _ = ClientSubnet
@@ -387,7 +387,7 @@ od_unknown code o = toOData $ OD_Unknown code o
 
 _showNSID :: OD_NSID -> String
 _showNSID (OD_NSID nsid) = "NSID "
-                        ++ b16encode bs
+                        ++ C8.unpack (Opaque.toBase16 nsid)
                         ++ ";"
                         ++ printable bs
   where

--- a/dnsext-types/DNS/Types/Imports.hs
+++ b/dnsext-types/DNS/Types/Imports.hs
@@ -15,18 +15,12 @@ module DNS.Types.Imports (
   , module Data.Typeable
   , module Data.Word
   , module Numeric
-  , b16encode
-  , b32encode
-  , b64encode
   ) where
 
 import Control.Applicative
 import Control.Monad
 import Data.Bits
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Base16 as B16
-import qualified Data.ByteString.Base64 as B64
-import qualified Data.ByteString.Char8  as C8
 import Data.ByteString.Short (ShortByteString)
 import Data.Function
 import Data.Int (Int64)
@@ -39,10 +33,3 @@ import Data.String
 import Data.Typeable
 import Data.Word
 import Numeric
-
-import qualified DNS.Types.Base32Hex as B32
-
-b16encode, b32encode, b64encode :: ByteString -> String
-b16encode = C8.unpack. B16.encode
-b32encode = C8.unpack. B32.encode
-b64encode = C8.unpack. B64.encode

--- a/dnsext-types/DNS/Types/Opaque.hs
+++ b/dnsext-types/DNS/Types/Opaque.hs
@@ -11,6 +11,12 @@ module DNS.Types.Opaque (
   , fromByteString
   , toShortByteString
   , fromShortByteString
+  , toBase16
+  , fromBase16
+  , toBase32Hex
+  , fromBase32Hex
+  , toBase64
+  , fromBase64
   ) where
 
 import Prelude hiding (null, concat, splitAt, length, foldr)

--- a/dnsext-types/DNS/Types/Opaque/Internal.hs
+++ b/dnsext-types/DNS/Types/Opaque/Internal.hs
@@ -1,6 +1,11 @@
 module DNS.Types.Opaque.Internal where
 
+import qualified Data.ByteString.Char8 as C8
 import qualified Data.ByteString.Short as Short
+
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Base64 as B64
+import qualified DNS.Types.Base32Hex as B32H
 
 import DNS.StateBinary
 import DNS.Types.Imports
@@ -24,7 +29,7 @@ showOpaque :: Opaque -> String
 showOpaque (Opaque o) = "\\# "
                      ++ show (Short.length o)
                      ++ " "
-                     ++ b16encode (Short.fromShort o)
+                     ++ C8.unpack (B16.encode $ Short.fromShort o)
 
 ----------------------------------------------------------------
 
@@ -39,6 +44,24 @@ toShortByteString (Opaque o) = o
 
 fromShortByteString :: ShortByteString -> Opaque
 fromShortByteString = Opaque
+
+toBase16 :: Opaque -> ByteString
+toBase16 (Opaque o) = B16.encode $ Short.fromShort o
+
+fromBase16 :: ByteString -> Either String Opaque
+fromBase16 = (Opaque . Short.toShort <$>) . B16.decode
+
+toBase32Hex :: Opaque -> ByteString
+toBase32Hex (Opaque o) = B32H.encode $ Short.fromShort o
+
+fromBase32Hex :: ByteString -> Either String Opaque
+fromBase32Hex = (Opaque . Short.toShort <$>) . B32H.decode
+
+toBase64 :: Opaque -> ByteString
+toBase64 (Opaque o) = B64.encode $ Short.fromShort o
+
+fromBase64 :: ByteString -> Either String Opaque
+fromBase64 = (Opaque . Short.toShort <$>) . B64.decode
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
Want to fix #49 by applying `decodeBase32Hex` instead of base32 package