### PR TITLE
Separate UpdateCache's dependence on full-resolver internal modules

### DIFF
--- a/dnsext-full-resolver/DNS/Cache/UpdateCache.hs
+++ b/dnsext-full-resolver/DNS/Cache/UpdateCache.hs
@@ -9,6 +9,7 @@ module DNS.Cache.UpdateCache (
 -- GHC packages
 import Control.Monad (forever)
 import Control.Concurrent (threadDelay)
+import Control.Concurrent.Chan (newChan, readChan, writeChan)
 import Data.IORef (newIORef, readIORef, atomicWriteIORef)
 
 -- dnsext-* packages
@@ -34,6 +35,13 @@ data MemoActions = MemoActions {
   , memoReadQueue :: IO UpdateEvent
   , memoWriteQueue :: UpdateEvent -> IO ()
   }
+
+getDefaultStubConf :: Int -> IO EpochTime -> IO CacheConf
+getDefaultStubConf size getSec = do
+  let noLog _ = pure ()
+  q <- newChan
+  pure $ CacheConf size $ MemoActions noLog noLog getSec (readChan q) (writeChan q)
+
 
 -- function update to update cache, and log action
 type UpdateEvent = (Cache -> Maybe Cache, Cache -> IO ())

--- a/dnsext-full-resolver/DNS/Cache/UpdateCache.hs
+++ b/dnsext-full-resolver/DNS/Cache/UpdateCache.hs
@@ -23,7 +23,8 @@ import DNS.Cache.Cache (Cache, Key, CRSet, Ranking)
 import qualified DNS.Cache.Cache as Cache
 
 data CacheConf = CacheConf {
-    memoActions :: MemoActions
+    maxCacheSize :: Int
+  , memoActions :: MemoActions
   }
 
 data MemoActions = MemoActions {
@@ -40,9 +41,8 @@ type UpdateEvent = (Cache -> Maybe Cache, Cache -> IO ())
 type Insert = Key -> TTL -> CRSet -> Ranking -> IO ()
 
 new :: CacheConf
-    -> Int
     -> IO ([IO ()], Insert, IO Cache, EpochTime -> IO ())
-new CacheConf{..} maxCacheSize = do
+new CacheConf{..} = do
   let MemoActions{..} = memoActions
   cacheRef <- newIORef $ Cache.empty maxCacheSize
 

--- a/dnsext-full-resolver/DNS/Cache/UpdateCache.hs
+++ b/dnsext-full-resolver/DNS/Cache/UpdateCache.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module DNS.Cache.UpdateCache (
+  CacheConf (..),
+  MemoActions (..),
+  getDefaultStubConf,
+  UpdateEvent,
   new,
   none,
   Insert,

--- a/dnsext-full-resolver/DNS/Cache/UpdateCache.hs
+++ b/dnsext-full-resolver/DNS/Cache/UpdateCache.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RecordWildCards #-}
+
 module DNS.Cache.UpdateCache (
   new,
   none,
@@ -19,9 +21,17 @@ import UnliftIO (tryAny)
 -- this package
 import DNS.Cache.Queue (newQueue, readQueue, writeQueue)
 import qualified DNS.Cache.Queue as Queue
-import qualified DNS.Cache.Log as Log
 import DNS.Cache.Cache (Cache, Key, CRSet, Ranking)
 import qualified DNS.Cache.Cache as Cache
+
+data CacheConf = CacheConf {
+    memoActions :: MemoActions
+  }
+
+data MemoActions = MemoActions {
+    memoLogLn :: String -> IO ()
+  , memoErrorLn :: String -> IO ()
+  }
 
 data Update
   = I Key TTL CRSet Ranking
@@ -36,39 +46,40 @@ runUpdate t u cache = case u of
 
 type Insert = Key -> TTL -> CRSet -> Ranking -> IO ()
 
-new :: (Log.Level -> [String] -> IO ()) -> (IO EpochTime, IO ShowS)
+new :: CacheConf
+    -> IO EpochTime
     -> Int
     -> IO ([IO ()], Insert, IO Cache, EpochTime -> IO (), IO (Int, Int))
-new putLines (getSec, getTimeStr) maxCacheSize = do
-  let putLn level = putLines level . (:[])
+new CacheConf{..} getSec maxCacheSize = do
+  let MemoActions{..} = memoActions
   cacheRef <- newIORef $ Cache.empty maxCacheSize
 
-  let update1 (ts, tstr, u) = do   -- step of single update theard
+  let update1 (ts, u) = do   -- step of single update theard
         cache <- readIORef cacheRef
         let updateRef c = do
               -- use atomicWrite to guard from out-of-order effect. to propagate updates to other CPU
               c `seq` atomicWriteIORef cacheRef c
               case u of
                 I {}  ->  return ()
-                E     ->  putLn Log.NOTICE $ tstr $ ": some records expired: size = " ++ show (Cache.size c)
+                E     ->  memoLogLn $ "some records expired: size = " ++ show (Cache.size c)
         maybe (pure ()) updateRef $ runUpdate ts u cache
 
   (updateLoop, enqueueU, readUSize) <- do
     inQ <- newQueue 8
-    let errorLn = putLn Log.NOTICE . ("UpdateCache.updateLoop: error: " ++) . show
+    let errorLn = memoErrorLn . ("Memo.updateLoop: error: " ++) . show
         body = either errorLn return =<< tryAny (update1 =<< readQueue inQ)
     return (forever body, writeQueue inQ, (,) <$> (fst <$> Queue.readSizes inQ) <*> pure (Queue.sizeMaxBound inQ))
 
-  let expires1 ts = enqueueU =<< (,,) ts <$> getTimeStr <*> pure E
+  let expires1 ts = enqueueU =<< (,) ts <$> pure E
 
       expireEvsnts = forever body
         where
-          errorLn = putLn Log.NOTICE . ("UpdateCache.expireEvents: error: " ++) . show
+          errorLn = memoErrorLn . ("Memo.expireEvents: error: " ++) . show
           interval = threadDelay $ 1800 * 1000 * 1000  -- when there is no insert for a long time
           body = either errorLn return =<< tryAny (interval *> (expires1 =<< getSec))
 
   let insert k ttl crs rank =
-        enqueueU =<< (,,) <$> getSec <*> getTimeStr <*> pure (I k ttl crs rank)
+        enqueueU =<< (,) <$> getSec <*> pure (I k ttl crs rank)
 
   return ([updateLoop, expireEvsnts], insert, readIORef cacheRef, expires1, readUSize)
 

--- a/dnsext-full-resolver/dug/FullResolve.hs
+++ b/dnsext-full-resolver/dug/FullResolve.hs
@@ -29,8 +29,9 @@ fullResolve disableV6NS logOutput logLevel n ty = do
 setup :: Bool -> Log.Output -> Log.Level -> IO (Log.Level -> [String] -> IO (), IO (), [IO ()], Context)
 setup disableV6NS logOutput logLevel = do
   (logLoop, putLines, _, flush) <- Log.new (Log.outputHandle logOutput) logLevel
-  tcache <- TimeCache.new
-  (loops, insert, getCache, _, _) <- UCache.new putLines tcache $ 4 * 1024
+  tcache@(getSec, _) <- TimeCache.new
+  cacheConf <- UCache.getDefaultStubConf (4 * 1024) getSec
+  (loops, insert, getCache, _) <- UCache.new cacheConf
   let ucache = (insert, getCache)
   cxt <- Iterative.newContext putLines disableV6NS ucache tcache
   return (putLines, flush, logLoop : loops, cxt)

--- a/dnsext-full-resolver/qtest/QuerySpec.hs
+++ b/dnsext-full-resolver/qtest/QuerySpec.hs
@@ -37,8 +37,9 @@ envSpec = describe "env" $ do
 
 cacheStateSpec :: Bool -> Spec
 cacheStateSpec disableV6NS = describe "cache-state" $ do
-  tcache <- runIO TimeCache.new
-  (loops, insert, getCache, _, _) <- runIO $ UCache.new (\_ _ -> pure ()) tcache $ 2 * 1024 * 1024
+  tcache@(getSec, _) <- runIO TimeCache.new
+  cacheConf <- runIO $ UCache.getDefaultStubConf (2 * 1024 * 1024) getSec
+  (loops, insert, getCache, _) <- runIO $ UCache.new cacheConf
   runIO $ mapM_ forkIO loops
 
   let getResolveCache n ty = do
@@ -68,8 +69,9 @@ cacheStateSpec disableV6NS = describe "cache-state" $ do
 
 querySpec :: Bool -> Spec
 querySpec disableV6NS = describe "query" $ do
-  tcache <- runIO TimeCache.new
-  (loops, insert, getCache, _, _) <- runIO $ UCache.new (\_ _ -> pure ()) tcache $ 2 * 1024 * 1024
+  tcache@(getSec, _) <- runIO TimeCache.new
+  cacheConf <- runIO $ UCache.getDefaultStubConf (2 * 1024 * 1024) getSec
+  (loops, insert, getCache, _) <- runIO $ UCache.new cacheConf
   runIO $ mapM_ forkIO loops
   let ucache = (insert, getCache)
   cxt <- runIO $ newContext (\_ _ -> pure ()) disableV6NS ucache tcache


### PR DESCRIPTION
Before considering the Reaper embedding,
Reduce direct dependencies on internal modules