### PR TITLE
Automatic DoX

### DIFF
--- a/dnsext-do53/DNS/Do53/Internal.hs
+++ b/dnsext-do53/DNS/Do53/Internal.hs
@@ -45,6 +45,7 @@ module DNS.Do53.Internal (
   , checkRespM
   , UDPRetry
   , VCLimit
+  , LookupEnv(..)
   , modifyLookupEnv
   , withLookupConfAndResolver
   ) where

--- a/dnsext-do53/DNS/Do53/LookupX.hs
+++ b/dnsext-do53/DNS/Do53/LookupX.hs
@@ -76,6 +76,7 @@ module DNS.Do53.LookupX (
   , lookupSRV
   , lookupX
   , lookupAuthX
+  , toResourceData
   ) where
 
 import DNS.Types
@@ -338,14 +339,14 @@ lookupSRV = lookupX SRV
 
 -- | Look up resource data in the answer section.
 lookupX :: ResourceData a => TYPE -> LookupEnv -> Domain -> IO (Either DNSError [a])
-lookupX typ env dom = unwrap <$> DNS.lookup env dom typ
+lookupX typ env dom = toResourceData <$> DNS.lookup env dom typ
 
 -- | Look up resource data in the authority section.
 lookupAuthX :: ResourceData a => TYPE -> LookupEnv -> Domain -> IO (Either DNSError [a])
-lookupAuthX typ env dom = unwrap <$> lookupAuth env dom typ
+lookupAuthX typ env dom = toResourceData <$> lookupAuth env dom typ
 
-unwrap :: ResourceData a => Either DNSError [RData] -> Either DNSError [a]
-unwrap erds = case erds of
+toResourceData :: ResourceData a => Either DNSError [RData] -> Either DNSError [a]
+toResourceData erds = case erds of
     Left err  -> Left err
     Right rds -> mapM unTag rds
 

--- a/dnsext-dox/DNS/DoX/Common.hs
+++ b/dnsext-dox/DNS/DoX/Common.hs
@@ -3,7 +3,6 @@
 module DNS.DoX.Common where
 
 import DNS.Do53.Internal (Recv)
-import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as C8
 import qualified Data.ByteString.Lazy as LBS
 import Data.Default.Class (def)
@@ -15,6 +14,8 @@ import Network.TLS hiding (HostName)
 import Network.TLS.Extra
 import System.IO.Error (isEOFError)
 import qualified UnliftIO.Exception as E
+
+import DNS.DoX.Imports
 
 ----------------------------------------------------------------
 

--- a/dnsext-dox/DNS/DoX/HTTP2.hs
+++ b/dnsext-dox/DNS/DoX/HTTP2.hs
@@ -12,7 +12,6 @@ import DNS.Types
 import DNS.Types.Decode
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as BB
-import Data.ByteString.Short (ShortByteString)
 import Data.ByteString.Short (fromShort)
 import Data.ByteString.Char8 ()
 import qualified Data.ByteString.Char8 as C8
@@ -26,6 +25,7 @@ import qualified System.TimeManager as T
 import qualified UnliftIO.Exception as E
 
 import DNS.DoX.Common
+import DNS.DoX.Imports
 
 http2Resolver :: ShortByteString -> VCLimit -> Resolver
 http2Resolver path lim ri@ResolvInfo{..} q qctl = E.bracket open close $ \sock ->

--- a/dnsext-dox/DNS/DoX/HTTP3.hs
+++ b/dnsext-dox/DNS/DoX/HTTP3.hs
@@ -7,7 +7,6 @@ import DNS.Do53.Client
 import DNS.Do53.Internal
 import DNS.Types
 import qualified Data.ByteString.Char8 as C8
-import Data.ByteString.Short (ShortByteString)
 import Network.HTTP3.Client
 import Network.QUIC
 import qualified Network.QUIC.Client as QUIC
@@ -15,6 +14,7 @@ import qualified UnliftIO.Exception as E
 
 import DNS.DoX.Common
 import DNS.DoX.HTTP2
+import DNS.DoX.Imports
 
 http3Resolver :: ShortByteString -> VCLimit -> Resolver
 http3Resolver path lim ri@ResolvInfo{..} q qctl = QUIC.run cc $ \conn ->

--- a/dnsext-dox/DNS/DoX/Imports.hs
+++ b/dnsext-dox/DNS/DoX/Imports.hs
@@ -1,0 +1,31 @@
+module DNS.DoX.Imports (
+    ByteString
+  , ShortByteString
+  , module Control.Applicative
+  , module Control.Monad
+  , module Data.Bits
+  , module Data.Function
+  , module Data.List
+  , module Data.Maybe
+  , module Data.Monoid
+  , module Data.Ord
+  , module Data.String
+  , module Data.Typeable
+  , module Data.Word
+  , module Numeric
+  ) where
+
+import Control.Applicative
+import Control.Monad
+import Data.Bits
+import Data.ByteString (ByteString)
+import Data.ByteString.Short (ShortByteString)
+import Data.Function
+import Data.List
+import Data.Maybe
+import Data.Monoid
+import Data.Ord
+import Data.String
+import Data.Typeable
+import Data.Word
+import Numeric

--- a/dnsext-dox/DNS/DoX/Stub.hs
+++ b/dnsext-dox/DNS/DoX/Stub.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
+
+module DNS.DoX.Stub (
+    doxPort
+  , makeResolver
+  , lookupDoX
+  ) where
+
+import Control.Exception (try)
+import DNS.Do53.Client
+import DNS.Do53.Internal
+import DNS.DoX.Internal
+import DNS.SVCB
+import DNS.Types
+import Network.Socket (PortNumber, HostName)
+
+import DNS.DoX.Imports
+
+doxPort :: ShortByteString -> PortNumber
+doxPort "dot" = 853
+doxPort "doq" = 853
+doxPort "h2"  = 443
+doxPort "h3"  = 443
+doxPort _     = 53
+
+makeResolver :: ShortByteString -> VCLimit -> Maybe ShortByteString -> Maybe Resolver
+makeResolver dox lim mpath = case dox of
+  "dot" -> Just $ tlsResolver lim
+  "doq" -> Just $ quicResolver lim
+  "h2"  -> Just $ http2Resolver (fromMaybe "/dns-query" mpath) lim
+  "h3"  -> Just $ http3Resolver (fromMaybe "/dns-query" mpath) lim
+  _     -> Nothing
+
+lookupDoX :: LookupConf -> HostName -> TYPE -> IO (Either DNSError Result)
+lookupDoX conf domain typ = do
+  let lim = lconfLimit conf
+      retry = lconfRetry conf
+      resolver = udpTcpResolver retry lim
+      q = Question "_dns.resolver.arpa" SVCB classIN
+  withLookupConfAndResolver conf resolver $ \lenv -> do
+      er <- lookupRaw lenv q
+      case er of
+        Left err -> return $ Left err
+        Right Result{..} -> do
+            let Reply{..} = resultReply
+                ss = sort (extractResourceData Answer replyDNSMessage) :: [RD_SVCB]
+            auto domain typ lim (lenvActions lenv) resultHostName ss
+
+auto :: HostName -> TYPE -> Int -> ResolvActions -> HostName -> [RD_SVCB] -> IO (Either DNSError Result)
+auto _ _ _ _ _ [] = return $ Left UnknownDNSError
+auto domain typ lim actions server ss0 = loop ss0
+  where
+    loop [] = return $ Left UnknownDNSError
+    loop (RD_SVCB{..}:ss) = do
+        let malpns = extractSvcParam SPK_ALPN svcb_params
+        case malpns of
+          Nothing -> loop ss
+          Just alpns -> go $ alpn_names alpns
+       where
+         q = Question (fromRepresentation domain) typ classIN
+         go [] = loop ss
+         go (alpn:alpns) = case makeResolver alpn lim Nothing of
+           Nothing -> go alpns
+           Just resolver  -> do
+               let port = maybe (doxPort alpn) port_number $ extractSvcParam SPK_Port svcb_params
+                   v4s = case extractSvcParam SPK_IPv4Hint svcb_params of
+                     Nothing -> []
+                     Just v4 -> show <$> hint_ipv4s v4
+                   v6s = case extractSvcParam SPK_IPv6Hint svcb_params of
+                     Nothing -> []
+                     Just v6 -> show <$> hint_ipv6s v6
+                   ips = case v4s ++ v6s of
+                     [] -> [(server,port)]
+                     xs -> map (,port) xs
+                   rinfos = map (\(x,y) -> ResolvInfo x y actions) ips
+                   renv = ResolvEnv resolver True rinfos
+               mrply <- try $ resolve renv q mempty
+               case mrply of
+                 Left _ -> go alpns
+                 _      -> return mrply

--- a/dnsext-dox/dnsext-dox.cabal
+++ b/dnsext-dox/dnsext-dox.cabal
@@ -20,7 +20,9 @@ source-repository head
     location: https://github.com/kazu-yamamoto/dnsext
 
 library
-    exposed-modules:  DNS.DoX.Internal
+    exposed-modules:
+        DNS.DoX.Internal
+        DNS.DoX.Stub
     other-modules:
         DNS.DoX.Common
         DNS.DoX.HTTP2
@@ -36,10 +38,12 @@ library
         bytestring,
         data-default-class,
         dnsext-do53,
+        dnsext-svcb,
         dnsext-types,
         http-types,
         http2,
         http3,
+        iproute,
         network >=2.3,
         quic,
         recv >=0.1.0,

--- a/dnsext-dox/dnsext-dox.cabal
+++ b/dnsext-dox/dnsext-dox.cabal
@@ -25,6 +25,7 @@ library
         DNS.DoX.Common
         DNS.DoX.HTTP2
         DNS.DoX.HTTP3
+        DNS.DoX.Imports
         DNS.DoX.QUIC
         DNS.DoX.TLS
 

--- a/dnsext-full-resolver/dug/Operation.hs
+++ b/dnsext-full-resolver/dug/Operation.hs
@@ -1,35 +1,108 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TupleSections #-}
 
 module Operation where
 
-import DNS.Do53.Client (QueryControls, LookupConf (..))
+import Control.Exception (try)
+import DNS.Do53.Client (QueryControls, LookupConf(..), Seeds(..))
 import qualified DNS.Do53.Client as DNS
-import DNS.Do53.Internal (withLookupConfAndResolver, udpTcpResolver)
+import DNS.Do53.Internal (withLookupConfAndResolver, udpTcpResolver, LookupEnv(..), Result(..), Reply(..), Result(..), ResolvEnv(..), ResolvInfo(..), Resolver, ResolvActions(..))
 import qualified DNS.Do53.Internal as DNS
 import DNS.DoX.Internal
-import DNS.Types (TYPE, DNSError)
+import DNS.SVCB
+import DNS.Types (DNSError, Question(..))
 import qualified DNS.Types as DNS
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Short as Short
 import Data.IP (IPv4, IPv6)
+import Data.List (sort)
+import Data.Maybe (fromMaybe)
 import Network.Socket (PortNumber, HostName)
 import Text.Read (readMaybe)
 
 data DoX = Do53 | Auto | DoT | DoQ | DoH2 | DoH3 deriving (Eq, Show)
 
-operate :: [HostName] -> PortNumber -> DoX -> HostName -> TYPE -> QueryControls -> IO (Either DNSError DNS.Result)
+doxPort :: DoX -> PortNumber
+doxPort Do53 = 53
+doxPort Auto = 53
+doxPort DoT  = 853
+doxPort DoQ  = 853
+doxPort DoH2 = 443
+doxPort DoH3 = 443
+
+toDoX :: String -> DoX
+toDoX "dot" = DoT
+toDoX "doq" = DoQ
+toDoX "h2"  = DoH2
+toDoX "h3"  = DoH3
+toDoX _     = Auto
+
+makeResolver :: DoX -> DNS.VCLimit -> Maybe DNS.UDPRetry -> Maybe Short.ShortByteString -> Resolver
+makeResolver dox lim mretry mpath = case dox of
+  DoT  -> tlsResolver lim
+  DoQ  -> quicResolver lim
+  DoH2 -> http2Resolver (fromMaybe "/dns-query" mpath) lim
+  DoH3 -> http3Resolver (fromMaybe "/dns-query" mpath) lim
+  _    -> udpTcpResolver (fromMaybe 3 mretry) lim
+
+operate :: [HostName] -> PortNumber -> DoX -> HostName -> TYPE -> QueryControls -> IO (Either DNSError Result)
+operate mserver port Auto domain typ controls = do
+  conf <- getCustomConf mserver port controls
+  let lim = DNS.lconfLimit conf
+      retry = DNS.lconfRetry conf
+      resolver = udpTcpResolver retry lim
+      q = Question "_dns.resolver.arpa" SVCB DNS.classIN
+  withLookupConfAndResolver conf resolver $ \lenv -> do
+      er <- DNS.lookupRaw lenv q
+      case er of
+        Left err -> return $ Left err
+        Right Result{..} -> do
+            let Reply{..} = resultReply
+                ss = sort (DNS.extractResourceData DNS.Answer replyDNSMessage) :: [RD_SVCB]
+            auto domain typ lim (lenvActions lenv) resultHostName ss
 operate mserver port dox domain typ controls = do
   conf <- getCustomConf mserver port controls
   let lim = DNS.lconfLimit conf
       retry = DNS.lconfRetry conf
-  let resolver = case dox of
-        DoT  -> tlsResolver lim
-        DoQ  -> quicResolver lim
-        DoH2 -> http2Resolver "/dns-query" lim
-        DoH3 -> http3Resolver "/dns-query" lim
-        _    -> udpTcpResolver retry lim
+      resolver = makeResolver dox lim (Just retry) Nothing
   withLookupConfAndResolver conf resolver $ \env -> do
-    let q = DNS.Question (DNS.fromRepresentation domain) typ DNS.classIN
+    let q = Question (DNS.fromRepresentation domain) typ DNS.classIN
     DNS.lookupRaw env q
+
+auto :: HostName -> TYPE -> Int -> ResolvActions -> HostName -> [RD_SVCB] -> IO (Either DNSError Result)
+auto _ _ _ _ _ [] = return $ Left DNS.UnknownDNSError
+auto domain typ lim actions server ss0 = loop ss0
+  where
+    loop [] = return $ Left DNS.UnknownDNSError
+    loop (RD_SVCB{..}:ss) = do
+        let malpns = extractSvcParam SPK_ALPN svcb_params
+        case malpns of
+          Nothing -> loop ss
+          Just alpns -> go $ alpn_names alpns
+       where
+         q = Question (DNS.fromRepresentation domain) typ DNS.classIN
+         go [] = loop ss
+         go (alpn:alpns) = case toDoX (BS.unpack (Short.fromShort alpn)) of
+           Auto -> go alpns
+           dox  -> do
+               let port = maybe (doxPort dox) port_number $ extractSvcParam SPK_Port svcb_params
+                   v4s = case extractSvcParam SPK_IPv4Hint svcb_params of
+                     Nothing -> []
+                     Just v4 -> show <$> hint_ipv4s v4
+                   v6s = case extractSvcParam SPK_IPv6Hint svcb_params of
+                     Nothing -> []
+                     Just v6 -> show <$> hint_ipv6s v6
+                   ips = case v4s ++ v6s of
+                     [] -> [(server,port)]
+                     xs -> map (,port) xs
+                   resolver = makeResolver dox lim Nothing Nothing
+                   rinfos = map (\(x,y) -> ResolvInfo x y actions) ips
+                   renv = ResolvEnv resolver True rinfos
+               mrply <- try $ DNS.resolve renv q mempty
+               case mrply of
+                 Left _ -> go alpns
+                 _      -> return mrply
 
 getCustomConf :: [HostName] -> PortNumber ->  QueryControls -> IO LookupConf
 getCustomConf mserver port controls = case mserver of
@@ -37,7 +110,7 @@ getCustomConf mserver port controls = case mserver of
   hs -> do
       as <- concat <$> mapM toNumeric hs
       let aps = map (,port) as
-      return $ conf { lconfSeeds = DNS.SeedsHostPorts aps }
+      return $ conf { lconfSeeds = SeedsHostPorts aps }
   where
     conf = DNS.defaultLookupConf {
         lconfRetry         = 2

--- a/dnsext-full-resolver/dug/Operation.hs
+++ b/dnsext-full-resolver/dug/Operation.hs
@@ -4,105 +4,32 @@
 
 module Operation where
 
-import Control.Exception (try)
 import DNS.Do53.Client (QueryControls, LookupConf(..), Seeds(..))
 import qualified DNS.Do53.Client as DNS
-import DNS.Do53.Internal (withLookupConfAndResolver, udpTcpResolver, LookupEnv(..), Result(..), Reply(..), Result(..), ResolvEnv(..), ResolvInfo(..), Resolver, ResolvActions(..))
-import qualified DNS.Do53.Internal as DNS
-import DNS.DoX.Internal
+import DNS.Do53.Internal (withLookupConfAndResolver, udpTcpResolver, Result(..), Result(..))
+import DNS.DoX.Stub
 import DNS.SVCB
 import DNS.Types (DNSError, Question(..))
 import qualified DNS.Types as DNS
-import qualified Data.ByteString.Char8 as BS
-import qualified Data.ByteString.Short as Short
+import Data.ByteString.Short (ShortByteString)
 import Data.IP (IPv4, IPv6)
-import Data.List (sort)
-import Data.Maybe (fromMaybe)
 import Network.Socket (PortNumber, HostName)
 import Text.Read (readMaybe)
 
-data DoX = Do53 | Auto | DoT | DoQ | DoH2 | DoH3 deriving (Eq, Show)
-
-doxPort :: DoX -> PortNumber
-doxPort Do53 = 53
-doxPort Auto = 53
-doxPort DoT  = 853
-doxPort DoQ  = 853
-doxPort DoH2 = 443
-doxPort DoH3 = 443
-
-toDoX :: String -> DoX
-toDoX "dot" = DoT
-toDoX "doq" = DoQ
-toDoX "h2"  = DoH2
-toDoX "h3"  = DoH3
-toDoX _     = Auto
-
-makeResolver :: DoX -> DNS.VCLimit -> Maybe DNS.UDPRetry -> Maybe Short.ShortByteString -> Resolver
-makeResolver dox lim mretry mpath = case dox of
-  DoT  -> tlsResolver lim
-  DoQ  -> quicResolver lim
-  DoH2 -> http2Resolver (fromMaybe "/dns-query" mpath) lim
-  DoH3 -> http3Resolver (fromMaybe "/dns-query" mpath) lim
-  _    -> udpTcpResolver (fromMaybe 3 mretry) lim
-
-operate :: [HostName] -> PortNumber -> DoX -> HostName -> TYPE -> QueryControls -> IO (Either DNSError Result)
-operate mserver port Auto domain typ controls = do
+operate :: [HostName] -> PortNumber -> ShortByteString -> HostName -> TYPE -> QueryControls -> IO (Either DNSError Result)
+operate mserver port dox domain typ controls | dox == "auto" = do
   conf <- getCustomConf mserver port controls
-  let lim = DNS.lconfLimit conf
-      retry = DNS.lconfRetry conf
-      resolver = udpTcpResolver retry lim
-      q = Question "_dns.resolver.arpa" SVCB DNS.classIN
-  withLookupConfAndResolver conf resolver $ \lenv -> do
-      er <- DNS.lookupRaw lenv q
-      case er of
-        Left err -> return $ Left err
-        Right Result{..} -> do
-            let Reply{..} = resultReply
-                ss = sort (DNS.extractResourceData DNS.Answer replyDNSMessage) :: [RD_SVCB]
-            auto domain typ lim (lenvActions lenv) resultHostName ss
+  lookupDoX conf domain typ
 operate mserver port dox domain typ controls = do
-  conf <- getCustomConf mserver port controls
-  let lim = DNS.lconfLimit conf
-      retry = DNS.lconfRetry conf
-      resolver = makeResolver dox lim (Just retry) Nothing
-  withLookupConfAndResolver conf resolver $ \env -> do
-    let q = Question (DNS.fromRepresentation domain) typ DNS.classIN
-    DNS.lookupRaw env q
-
-auto :: HostName -> TYPE -> Int -> ResolvActions -> HostName -> [RD_SVCB] -> IO (Either DNSError Result)
-auto _ _ _ _ _ [] = return $ Left DNS.UnknownDNSError
-auto domain typ lim actions server ss0 = loop ss0
-  where
-    loop [] = return $ Left DNS.UnknownDNSError
-    loop (RD_SVCB{..}:ss) = do
-        let malpns = extractSvcParam SPK_ALPN svcb_params
-        case malpns of
-          Nothing -> loop ss
-          Just alpns -> go $ alpn_names alpns
-       where
-         q = Question (DNS.fromRepresentation domain) typ DNS.classIN
-         go [] = loop ss
-         go (alpn:alpns) = case toDoX (BS.unpack (Short.fromShort alpn)) of
-           Auto -> go alpns
-           dox  -> do
-               let port = maybe (doxPort dox) port_number $ extractSvcParam SPK_Port svcb_params
-                   v4s = case extractSvcParam SPK_IPv4Hint svcb_params of
-                     Nothing -> []
-                     Just v4 -> show <$> hint_ipv4s v4
-                   v6s = case extractSvcParam SPK_IPv6Hint svcb_params of
-                     Nothing -> []
-                     Just v6 -> show <$> hint_ipv6s v6
-                   ips = case v4s ++ v6s of
-                     [] -> [(server,port)]
-                     xs -> map (,port) xs
-                   resolver = makeResolver dox lim Nothing Nothing
-                   rinfos = map (\(x,y) -> ResolvInfo x y actions) ips
-                   renv = ResolvEnv resolver True rinfos
-               mrply <- try $ DNS.resolve renv q mempty
-               case mrply of
-                 Left _ -> go alpns
-                 _      -> return mrply
+    conf <- getCustomConf mserver port controls
+    let lim = DNS.lconfLimit conf
+        resolver = case makeResolver dox lim Nothing of
+          Just r -> r
+          Nothing -> let retry = DNS.lconfRetry conf
+                     in udpTcpResolver lim retry
+    withLookupConfAndResolver conf resolver $ \env -> do
+        let q = Question (DNS.fromRepresentation domain) typ DNS.classIN
+        DNS.lookupRaw env q
 
 getCustomConf :: [HostName] -> PortNumber ->  QueryControls -> IO LookupConf
 getCustomConf mserver port controls = case mserver of

--- a/dnsext-full-resolver/dug/dug.hs
+++ b/dnsext-full-resolver/dug/dug.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Main (main) where
@@ -5,9 +6,13 @@ module Main (main) where
 import Control.Monad (when)
 import DNS.Do53.Client (rdFlag, doFlag, QueryControls, FlagOp(..))
 import DNS.Do53.Internal (Result(..), Reply(..))
+import DNS.DoX.Stub
 import DNS.SEC (addResourceDataForDNSSEC)
 import DNS.SVCB (addResourceDataForSVCB)
 import DNS.Types (TYPE(..), runInitIO)
+import qualified Data.ByteString.Char8 as C8
+import Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Short as Short
 import Data.List (isPrefixOf, intercalate)
 import qualified Data.UnixTime as T
 import System.Console.GetOpt
@@ -17,7 +22,7 @@ import Text.Read (readMaybe)
 
 import qualified DNS.Cache.Log as Log
 
-import Operation (operate, DoX(..), toDoX, doxPort)
+import Operation (operate)
 import FullResolve (fullResolve)
 import Output (pprResult)
 
@@ -36,8 +41,8 @@ options = [
     (ReqArg (\ port opts -> opts { optPort = Just port }) "<port>")
     "specify port number"
   , Option ['d'] ["dox"]
-    (ReqArg (\ dox opts -> opts { optDoX = toDoX dox }) "dot|doq|h2|h3")
-    "enable DoX (auto if unknown"
+    (ReqArg (\ dox opts -> opts { optDoX = Short.toShort (C8.pack dox) }) "auto|dot|doq|h2|h3")
+    "enable DoX"
   ]
 
 data Options = Options {
@@ -45,7 +50,7 @@ data Options = Options {
   , optIterative   :: Bool
   , optDisableV6NS :: Bool
   , optPort        :: Maybe String
-  , optDoX         :: DoX
+  , optDoX         :: ShortByteString
   } deriving Show
 
 defaultOptions :: Options
@@ -54,7 +59,7 @@ defaultOptions    = Options {
   , optIterative   = False
   , optDisableV6NS = False
   , optPort        = Nothing
-  , optDoX         = Do53
+  , optDoX         = "do53"
   }
 
 main :: IO ()
@@ -106,7 +111,7 @@ main = do
           Left err -> fail $ show err
           Right Result{..} -> do
               let Reply{..} = resultReply
-              putStr $ ";; " ++ resultHostName ++ "@" ++ show resultPortNumber ++ "/" ++ resultTag
+              putStr $ ";; " ++ resultHostName ++ "#" ++ show resultPortNumber ++ "/" ++ resultTag
               putStr $ ", Tx:" ++ show replyTxBytes ++ "bytes"
               putStr $ ", Rx:" ++ show replyRxBytes ++ "bytes"
               putStr   ", "

--- a/dnsext-full-resolver/dug/dug.hs
+++ b/dnsext-full-resolver/dug/dug.hs
@@ -10,7 +10,6 @@ import DNS.SVCB (addResourceDataForSVCB)
 import DNS.Types (TYPE(..), runInitIO)
 import Data.List (isPrefixOf, intercalate)
 import qualified Data.UnixTime as T
-import Network.Socket (PortNumber)
 import System.Console.GetOpt
 import System.Environment (getArgs)
 import System.Exit (exitSuccess, exitFailure)
@@ -18,7 +17,7 @@ import Text.Read (readMaybe)
 
 import qualified DNS.Cache.Log as Log
 
-import Operation (operate, DoX(..))
+import Operation (operate, DoX(..), toDoX, doxPort)
 import FullResolve (fullResolve)
 import Output (pprResult)
 
@@ -37,24 +36,9 @@ options = [
     (ReqArg (\ port opts -> opts { optPort = Just port }) "<port>")
     "specify port number"
   , Option ['d'] ["dox"]
-    (ReqArg (\ dox opts -> opts { optDoX = toDoX dox }) "dot|doq|doh2|doh3")
+    (ReqArg (\ dox opts -> opts { optDoX = toDoX dox }) "dot|doq|h2|h3")
     "enable DoX (auto if unknown"
   ]
-
-toDoX :: String -> DoX
-toDoX "dot"  = DoT
-toDoX "doq"  = DoQ
-toDoX "doh2" = DoH2
-toDoX "doh3" = DoH3
-toDoX _      = Auto
-
-doxPort :: DoX -> PortNumber
-doxPort Do53 = 53
-doxPort Auto = 53
-doxPort DoT  = 853
-doxPort DoQ  = 853
-doxPort DoH2 = 443
-doxPort DoH3 = 443
 
 data Options = Options {
     optHelp        :: Bool

--- a/dnsext-types/DNS/Types.hs
+++ b/dnsext-types/DNS/Types.hs
@@ -6,6 +6,8 @@ module DNS.Types (
   , makeQuery
   , defaultResponse
   , makeResponse
+  , extractResourceData
+  , Section(..)
   -- ** Header
   , DNSHeader(..)
   , Identifier

--- a/dnsext-types/DNS/Types/Internal.hs
+++ b/dnsext-types/DNS/Types/Internal.hs
@@ -7,6 +7,8 @@ module DNS.Types.Internal (
   -- * Classes
   , ResourceData(..)
   , OptData(..)
+  -- * Misc
+  , section
   -- * Extension
   , extendRR
   , extendOpt

--- a/dnsext-types/DNS/Types/Message.hs
+++ b/dnsext-types/DNS/Types/Message.hs
@@ -642,3 +642,15 @@ getResourceRecord = do
     len <- getInt16
     dat <- getRData typ len
     return $ ResourceRecord dom typ cls ttl dat
+
+----------------------------------------------------------------
+
+data Section = Answer | Authority | Additional deriving (Eq, Ord, Show)
+
+section :: Section -> DNSMessage -> Answers
+section Answer     = answer
+section Authority  = authority
+section Additional = additional
+
+extractResourceData :: ResourceData a => Section -> DNSMessage -> [a]
+extractResourceData sec = catMaybes . map (fromRData . rdata) . section sec


### PR DESCRIPTION
This PR lets `dug` look up SVCB RR first then use the selected DoX to resolve the target if `-d auto` is specified.