### PR TITLE
`Opaque → PubKey → Opaque` conversion did not satisfy the isomorphism

### DIFF
--- a/dnsext-dnssec/DNS/SEC/PubKey.hs
+++ b/dnsext-dnssec/DNS/SEC/PubKey.hs
@@ -50,12 +50,12 @@ toPubKey_ECDSA len o
 fromPubKey :: PubKey -> Opaque
 fromPubKey (PubKey_RSA _len e n)
     | elen >= 256 = let (x,y) = elen `divMod` 256
-                   in Opaque.concat [ Opaque.singleton 0
-                                    , Opaque.singleton $ fromIntegral x
-                                    , Opaque.singleton $ fromIntegral y
-                                    , e
-                                    , n
-                                           ]
+                    in Opaque.concat [ Opaque.singleton 0
+                                     , Opaque.singleton $ fromIntegral x
+                                     , Opaque.singleton $ fromIntegral y
+                                     , e
+                                     , n
+                                     ]
     | otherwise  = Opaque.concat [ Opaque.singleton $ fromIntegral elen
                                  , e
                                  , n

--- a/dnsext-dnssec/DNS/SEC/PubKey.hs
+++ b/dnsext-dnssec/DNS/SEC/PubKey.hs
@@ -49,7 +49,7 @@ toPubKey_ECDSA len o
 
 fromPubKey :: PubKey -> Opaque
 fromPubKey (PubKey_RSA _len e n)
-    | elen > 1   = let (x,y) = elen `divMod` 256
+    | elen >= 256 = let (x,y) = elen `divMod` 256
                    in Opaque.concat [ Opaque.singleton 0
                                     , Opaque.singleton $ fromIntegral x
                                     , Opaque.singleton $ fromIntegral y


### PR DESCRIPTION
There was still a problem with the `RSA` case of `fromPubKey`,
which broke the isomorphism property of the `Opaque → PubKey → Opaque` orientation.