### PR TITLE
Root Priming - refresh root server informations with DNSSEC verification

### DIFF
--- a/dnsext-full-resolver/DNS/Cache/Iterative.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative.hs
@@ -8,7 +8,7 @@ module DNS.Cache.Iterative (
   runResolveJust,
   newEnv,
   runIterative,
-  rootHint, rootNS, Delegation,
+  rootHint, Delegation,
   QueryError (..),
   printResult,
   -- * types
@@ -604,9 +604,6 @@ v4DEntryList des@(de:_)  =  concatMap skipAAAA $ byNS des
         aaaaDE _                      = False
         nullCase     []    =  [DEonlyNS (nsDomain de)]
         nullCase es@(_:_)  =  es
-
-rootNS :: Delegation
-rootNS = rootHint
 
 -- {-# ANN rootHint ("HLint: ignore Use tuple-section") #-}
 rootHint :: Delegation

--- a/dnsext-full-resolver/DNS/Cache/Iterative.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative.hs
@@ -8,7 +8,7 @@ module DNS.Cache.Iterative (
   runResolveJust,
   newEnv,
   runIterative,
-  rootNS, Delegation,
+  rootHint, rootNS, Delegation,
   QueryError (..),
   printResult,
   -- * types
@@ -600,12 +600,14 @@ v4DEntryList des@(de:_)  =  concatMap skipAAAA $ byNS des
         nullCase     []    =  [DEonlyNS (nsDomain de)]
         nullCase es@(_:_)  =  es
 
--- {-# ANN rootNS ("HLint: ignore Use fromMaybe") #-}
--- {-# ANN rootNS ("HLint: ignore Use tuple-section") #-}
 rootNS :: Delegation
-rootNS =
+rootNS = rootHint
+
+-- {-# ANN rootHint ("HLint: ignore Use tuple-section") #-}
+rootHint :: Delegation
+rootHint =
   fromMaybe
-  (error "rootNS: bad configuration.")
+  (error "rootHint: bad configuration.")
   $ takeDelegationSrc (nsList "." (,) ns) [] as
   where
     (ns, as) = rootServers

--- a/dnsext-full-resolver/DNS/Cache/RootTrustAnchors.hs
+++ b/dnsext-full-resolver/DNS/Cache/RootTrustAnchors.hs
@@ -1,10 +1,9 @@
-
+{-# LANGUAGE OverloadedStrings #-}
 
 module DNS.Cache.RootTrustAnchors (
   rootSepDS
   ) where
 
-import Data.String (fromString)
 import qualified DNS.Types.Opaque as Opaque
 import DNS.SEC
 
@@ -15,5 +14,4 @@ rootSepDS = RD_DS 20326 (PubAlg 8) (DigestAlg 2) digest
   where
     digest =
       either (error . ("rootSepDS: bad configuration: " ++)) id
-      $ Opaque.fromBase16
-      $ fromString "E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D"
+      $ Opaque.fromBase16 "E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D"

--- a/dnsext-full-resolver/DNS/Cache/RootTrustAnchors.hs
+++ b/dnsext-full-resolver/DNS/Cache/RootTrustAnchors.hs
@@ -1,0 +1,19 @@
+
+
+module DNS.Cache.RootTrustAnchors (
+  rootSepDS
+  ) where
+
+import Data.String (fromString)
+import qualified DNS.Types.Opaque as Opaque
+import DNS.SEC
+
+{- import trust-anchor DS RData from
+   https://data.iana.org/root-anchors/root-anchors.xml -}
+rootSepDS :: RD_DS
+rootSepDS = RD_DS 20326 (PubAlg 8) (DigestAlg 2) digest
+  where
+    digest =
+      either (error . ("rootSepDS: bad configuration: " ++)) id
+      $ Opaque.fromBase16
+      $ fromString "E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D"

--- a/dnsext-full-resolver/dnsext-full-resolver.cabal
+++ b/dnsext-full-resolver/dnsext-full-resolver.cabal
@@ -18,6 +18,7 @@ library
     other-modules:
         DNS.Cache.ServerMonitor
         DNS.Cache.RootServers
+        DNS.Cache.RootTrustAnchors
         DNS.Cache.SocketUtil
         DNS.Cache.Queue
 

--- a/dnsext-full-resolver/qtest/QuerySpec.hs
+++ b/dnsext-full-resolver/qtest/QuerySpec.hs
@@ -12,7 +12,7 @@ import qualified DNS.Do53.Memo as Cache
 import System.Environment (lookupEnv)
 
 import qualified DNS.Cache.TimeCache as TimeCache
-import DNS.Cache.Iterative (newEnv, runDNSQuery, replyMessage, replyResult, rootHint, Env (..))
+import DNS.Cache.Iterative (newEnv, runDNSQuery, replyMessage, replyResult, rootHint, Env (..), Delegation (..))
 import qualified DNS.Cache.Iterative as Iterative
 
 data AnswerResult
@@ -31,7 +31,7 @@ spec = do
 envSpec :: Spec
 envSpec = describe "env" $ do
   it "rootHint" $ do
-    let sp p = case p of (_,_,_,_) -> True  -- check not error
+    let sp p = case p of Delegation _ _ _ _ -> True  -- check not error
     rootHint `shouldSatisfy` sp
 
 cacheStateSpec :: Bool -> Spec

--- a/dnsext-full-resolver/qtest/QuerySpec.hs
+++ b/dnsext-full-resolver/qtest/QuerySpec.hs
@@ -31,7 +31,7 @@ spec = do
 envSpec :: Spec
 envSpec = describe "env" $ do
   it "rootNS" $ do
-    let sp p = case p of (_,_) -> True  -- check not error
+    let sp p = case p of (_,_,_,_) -> True  -- check not error
     rootNS `shouldSatisfy` sp
 
 cacheStateSpec :: Bool -> Spec


### PR DESCRIPTION
Get the latest root server information and DNSKEY from root-hint, and use DNSSEC to verify that the content matches the trust anchor.