### PR TITLE
verify DNSSEC signatures during iterative lookups

### DIFF
--- a/dnsext-full-resolver/DNS/Cache/Iterative.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative.hs
@@ -729,7 +729,9 @@ iterative_ dc nss0 (x:xs) =
       let withNXC nxc
             | nxc        =  return NoDelegation
             | otherwise  =  stepQuery nss
-      maybe (withNXC =<< lift lookupNX) return =<< lift (lookupDelegation name)
+      md <- maybe (withNXC =<< lift lookupNX) return =<< lift (lookupDelegation name)
+      let fills d = fillDelegationDNSKEY =<< fillDelegationDS nss d
+      mayDelegation (return NoDelegation) (fmap HasDelegation . fills) md
 
 -- If Nothing, it is a miss-hit against the cache.
 -- If Just NoDelegation, cache hit but no delegation information.

--- a/dnsext-full-resolver/DNS/Cache/Iterative.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative.hs
@@ -640,10 +640,11 @@ resolveJustDC dc n typ
   | otherwise  = do
   lift $ logLn Log.INFO $ "resolve-just: " ++ "dc=" ++ show dc ++ ", " ++ show (n, typ)
   root <- refreshRoot
-  nss <- iterative_ dc root $ reverse $ DNS.superDomains n
+  nss@Delegation{..} <- iterative_ dc root $ reverse $ DNS.superDomains n
   sas <- delegationIPs dc nss
   lift $ logLines Log.INFO $ [ "resolve-just: selected addrs: " ++ show (sa, n, typ) | sa <- sas ]
-  (,) <$> norec False sas n typ <*> pure nss
+  let dnssecOK = not (null delegationDS) && not (null delegationDNSKEY)
+  (,) <$> norec dnssecOK sas n typ <*> pure nss
     where
       mdc = maxNotSublevelDelegation
 

--- a/dnsext-full-resolver/dnsext-full-resolver.cabal
+++ b/dnsext-full-resolver/dnsext-full-resolver.cabal
@@ -112,6 +112,7 @@ test-suite spec
         base,
         hspec,
         dnsext-types,
+        dnsext-dnssec,
         dnsext-do53,
         dnsext-full-resolver
 

--- a/dnsext-full-resolver/dug/FullResolve.hs
+++ b/dnsext-full-resolver/dug/FullResolve.hs
@@ -7,7 +7,7 @@ import qualified DNS.Do53.Memo as Cache
 
 import qualified DNS.Cache.Log as Log
 import qualified DNS.Cache.TimeCache as TimeCache
-import DNS.Cache.Iterative (Env (..), QueryError)
+import DNS.Cache.Iterative (Env (..), QueryError, IterativeControls)
 import qualified DNS.Cache.Iterative as Iterative
 
 import DNS.Types
@@ -15,13 +15,14 @@ import DNS.Types
 fullResolve :: Bool
             -> Log.Output
             -> Log.Level
+            -> IterativeControls
             -> String
             -> TYPE
             -> IO (Either QueryError DNSMessage)
-fullResolve disableV6NS logOutput logLevel n ty = do
+fullResolve disableV6NS logOutput logLevel ctl n ty = do
   (putLines, flushLog, loops, cxt) <- setup disableV6NS logOutput logLevel
   mapM_ forkIO $ loops
-  out <- resolve cxt n ty
+  out <- resolve cxt ctl n ty
   putLines Log.INFO ["--------------------"]
   flushLog
   return out
@@ -37,10 +38,10 @@ setup disableV6NS logOutput logLevel = do
   cxt <- Iterative.newEnv putLines disableV6NS ucache tcache
   return (putLines, flush, [logLoop], cxt)
 
-resolve :: Env -> String -> TYPE -> IO (Either QueryError DNSMessage)
-resolve cxt n ty =
+resolve :: Env -> IterativeControls -> String -> TYPE -> IO (Either QueryError DNSMessage)
+resolve cxt ictl n ty =
   fmap toMessage <$>
-  Iterative.runDNSQuery (Iterative.replyResult (fromString n) ty) cxt Iterative.defaultIterativeControls
+  Iterative.runDNSQuery (Iterative.replyResult (fromString n) ty) cxt ictl
   where
     toMessage (rc, ans, auth) = defaultResponse { DNS.header = h { DNS.flags = f }, DNS.answer = ans, DNS.authority = auth }
       where

--- a/dnsext-full-resolver/qtest/QuerySpec.hs
+++ b/dnsext-full-resolver/qtest/QuerySpec.hs
@@ -91,6 +91,10 @@ querySpec disableV6NS = describe "query" $ do
         | null (DNS.answer msg)  =  Empty    rcode
         | otherwise              =  NotEmpty rcode
         where rcode = DNS.rcode $ DNS.flags $ DNS.header msg
+      checkVAnswer (msg, (vans, _))
+        | null vans  =  Empty    rcode
+        | otherwise  =  NotEmpty rcode
+        where rcode = DNS.rcode $ DNS.flags $ DNS.header msg
       checkResult = either (const Failed) (checkAnswer . fst)
 
   it "root-priming" $ do
@@ -161,7 +165,7 @@ querySpec disableV6NS = describe "query" $ do
     let cached (rcode, rrs, _)
           | null rrs   =  Empty rcode
           | otherwise  =  NotEmpty rcode
-    either (const Failed) (either cached checkAnswer) result `shouldBe` NotEmpty DNS.NoErr
+    either (const Failed) (either cached checkVAnswer) result `shouldBe` NotEmpty DNS.NoErr
 
   it "resolve - a via cname" $ do
     result <- runResolve "clients4.google.com." A

--- a/dnsext-full-resolver/qtest/QuerySpec.hs
+++ b/dnsext-full-resolver/qtest/QuerySpec.hs
@@ -8,6 +8,7 @@ import Data.Either (isRight)
 import Data.String (fromString)
 import DNS.Types (TYPE(NS, A, AAAA, MX, CNAME, PTR, SOA))
 import qualified DNS.Types as DNS
+import qualified DNS.SEC as DNS
 import qualified DNS.Do53.Memo as Cache
 import System.Environment (lookupEnv)
 
@@ -19,6 +20,17 @@ data AnswerResult
   = Empty    DNS.RCODE
   | NotEmpty DNS.RCODE
   | Failed
+  deriving (Eq, Show)
+
+data VerifyResult
+  = Verified
+  | NotVerified
+  deriving (Eq, Show)
+
+data VAnswerResult
+  = VEmpty    DNS.RCODE
+  | VNotEmpty DNS.RCODE VerifyResult
+  | VFailed
   deriving (Eq, Show)
 
 spec :: Spec
@@ -69,6 +81,7 @@ cacheStateSpec disableV6NS = describe "cache-state" $ do
 
 querySpec :: Bool -> Spec
 querySpec disableV6NS = describe "query" $ do
+  runIO $ DNS.runInitIO DNS.addResourceDataForDNSSEC
   tcache@(getSec, _) <- runIO TimeCache.new
   let cacheConf = Cache.getDefaultStubConf (2 * 1024 * 1024) 600 getSec
   memo <- runIO $ Cache.getMemo cacheConf
@@ -86,14 +99,22 @@ querySpec disableV6NS = describe "query" $ do
 
   let printQueryError :: Show e => Either e a -> IO ()
       printQueryError = either (putStrLn . ("    QueryError: " ++) . show) (const $ pure ())
+      _pprResult (msg, (ans, auth)) =
+        unlines $
+        ("rcode: " ++ show (DNS.rcode $ DNS.flags $ DNS.header msg)) :
+        "answer:" : map (("  " ++) . show) ans ++
+        "authority:" : map (("  " ++) . show) auth
 
       checkAnswer msg
         | null (DNS.answer msg)  =  Empty    rcode
         | otherwise              =  NotEmpty rcode
         where rcode = DNS.rcode $ DNS.flags $ DNS.header msg
+      verified rrsets
+        | all Iterative.rrsetVerified rrsets  =  Verified
+        | otherwise                           =  NotVerified
       checkVAnswer (msg, (vans, _))
-        | null vans  =  Empty    rcode
-        | otherwise  =  NotEmpty rcode
+        | null vans  =  VEmpty    rcode
+        | otherwise  =  VNotEmpty rcode (verified vans)
         where rcode = DNS.rcode $ DNS.flags $ DNS.header msg
       checkResult = either (const Failed) (checkAnswer . fst)
 
@@ -163,14 +184,23 @@ querySpec disableV6NS = describe "query" $ do
     result <- runResolve "porttest.dns-oarc.net." CNAME
     printQueryError result
     let cached (rcode, rrs, _)
-          | null rrs   =  Empty rcode
-          | otherwise  =  NotEmpty rcode
-    either (const Failed) (either cached checkVAnswer) result `shouldBe` NotEmpty DNS.NoErr
+          | null rrs   =  VEmpty rcode
+          | otherwise  =  VNotEmpty rcode NotVerified
+    either (const VFailed) (either cached checkVAnswer) result `shouldBe` VNotEmpty DNS.NoErr Verified
 
   it "resolve - a via cname" $ do
     result <- runResolve "clients4.google.com." A
     printQueryError result
     isRight result `shouldBe` True
+
+  it "resolve - a with DNSSEC_OK" $ do
+    result <- runResolve "iij.ad.jp." A
+    printQueryError result
+    isRight result `shouldBe` True
+    let cached (rcode, rrs, _)
+          | null rrs   =  VEmpty rcode
+          | otherwise  =  VNotEmpty rcode NotVerified
+    either (const VFailed) (either cached checkVAnswer) result `shouldBe` VNotEmpty DNS.NoErr Verified
 
   it "get-reply - nx via cname" $ do
     result <- getReply "media.yahoo.com." A 0


### PR DESCRIPTION


```
％ dug -i iij.ad.jp. A +dnssec

...
delegationWithCache: "." -> "jp.", success: verifying RRSIG of DS
...
delegationWithCache: "jp." -> "ad.jp.", no delegation.
...
delegationWithCache: "jp." -> "iij.ad.jp.", success: verifying RRSIG of DS
...
```