### PR TITLE
ServFail on DNSSEC verification failure, and DEMO logging

### DIFF
--- a/dnsext-full-resolver/DNS/Cache/Iterative.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative.hs
@@ -777,6 +777,7 @@ iterative_ dc nss0 (x:xs) =
             filled@Delegation{..} <- fillDelegationDNSKEY dc =<< fillDelegationDS dc nss d
             when (not (null delegationDS) && null delegationDNSKEY) $ do
               lift $ logLn Log.NOTICE $ "iterative_.step: " ++ show delegationZoneDomain ++ ": " ++ "DS is not null, and DNSKEY is null"
+              lift $ logLn Log.DEMO $ show delegationZoneDomain ++ ": verification error. dangling DS chain. DS exists, and DNSKEY does not exists"
               throwDnsError DNS.ServerFailure
             return filled
       mayDelegation (return NoDelegation) (fmap HasDelegation . fills) md

--- a/dnsext-full-resolver/DNS/Cache/Iterative.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative.hs
@@ -841,16 +841,18 @@ delegationWithCache zoneDom dnskeys dom msg = do
           else                     cacheEmptySection zoneDom dnskeys dom Cache.nxTYPE rankedAuthority msg
         | otherwise             =  pure []
         where rcode = DNS.rcode $ DNS.flags $ DNS.header msg
+      demoNoDelegation =  logLn Log.DEMO $ "no delegation: " ++ domTraceMsg
 
   let withCache x = do
         cacheDS
         cacheNS
         cacheAdds
+        logLn Log.DEMO $ verifyMsg ++ ": " ++ domTraceMsg ++ "\n" ++ ppDelegation (delegationNS x)
         return x
 
   logLn Log.INFO $ "delegationWithCache: " ++ domTraceMsg ++ ", " ++ verifyMsg
   maybe
-    (ncache $> NoDelegation)
+    (ncache *> demoNoDelegation $> NoDelegation)
     (fmap HasDelegation . withCache)
     $ takeDelegationSrc nsps dss adds
   where

--- a/dnsext-full-resolver/DNS/Cache/Iterative.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative.hs
@@ -1179,6 +1179,7 @@ axList disableV6NS pdom h = foldr takeAx []
 norec :: Bool -> [IP] -> Domain -> TYPE -> DNSQuery DNSMessage
 norec dnsssecOK aservers name typ = dnsQueryT $ \cxt _qctl -> do
   logLines_ cxt Log.DEBUG $ ["norec: " ++ show name ++ ", " ++ show typ ++ ", " ++ show aservers]
+  logLines_ cxt Log.DEMO $ ["query " ++ show name ++ " " ++ show typ ++ " to " ++ show aservers]
   let ris =
         [ defaultResolvInfo {
             rinfoHostName   = show aserver

--- a/dnsext-full-resolver/DNS/Cache/Iterative.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative.hs
@@ -661,6 +661,7 @@ cacheAnswer Delegation{..} dom typ msg
               | rrsetVerified xRRset  =  ("verification success - RRSIG of " ++ show dom ++ " " ++ show typ, pure ())
               | otherwise             =  ("verification failed - RRSIG of " ++ show dom ++ " " ++ show typ, throwDnsError DNS.ServerFailure)
         lift $ logLn Log.INFO $ "cacheAnswer: " ++ verifyMsg
+        lift $ logLn Log.DEMO verifyMsg
         raiseOnVerifyFailure
         return ([xRRset], [])
   where

--- a/dnsext-full-resolver/DNS/Cache/Log.hs
+++ b/dnsext-full-resolver/DNS/Cache/Log.hs
@@ -49,9 +49,8 @@ type PutLines = Level -> [String] -> IO ()
 type GetQueueSize = IO (Int, Int)
 type Flush = IO ()
 
-newFastLogger :: Output -> Level -> IO (PutLines, GetQueueSize, Flush)
-newFastLogger out loggerLevel = do
-  let demoFlag = DisableDemo
+newFastLogger :: Output -> Level -> DemoFlag -> IO (PutLines, GetQueueSize, Flush)
+newFastLogger out loggerLevel demoFlag = do
   loggerSet <- newLoggerSet bufsize
   let enabled lv = checkEnabledLevelWithDemo loggerLevel demoFlag lv
       logLines lv = when (enabled lv) . pushLogStr loggerSet . toLogStr . unlines
@@ -67,9 +66,8 @@ outputHandle o = case o of
   Stdout  ->  stdout
   Stderr  ->  stderr
 
-new :: Handle -> Level -> IO (ThreadLoop, PutLines, GetQueueSize, Flush)
-new outFh loggerLevel = do
-  let demoFlag = DisableDemo
+new :: Handle -> Level -> DemoFlag -> IO (ThreadLoop, PutLines, GetQueueSize, Flush)
+new outFh loggerLevel demoFlag = do
   hSetBuffering outFh LineBuffering
 
   inQ <- newQueue 8

--- a/dnsext-full-resolver/dug/FullResolve.hs
+++ b/dnsext-full-resolver/dug/FullResolve.hs
@@ -2,12 +2,11 @@ module FullResolve where
 
 import Control.Concurrent (forkIO)
 import Data.String (fromString)
-import qualified DNS.Types as DNS
 import qualified DNS.Do53.Memo as Cache
 
 import qualified DNS.Cache.Log as Log
 import qualified DNS.Cache.TimeCache as TimeCache
-import DNS.Cache.Iterative (Env (..), QueryError, IterativeControls)
+import DNS.Cache.Iterative (Env (..), IterativeControls)
 import qualified DNS.Cache.Iterative as Iterative
 
 import DNS.Types
@@ -18,7 +17,7 @@ fullResolve :: Bool
             -> IterativeControls
             -> String
             -> TYPE
-            -> IO (Either QueryError DNSMessage)
+            -> IO (Either String DNSMessage)
 fullResolve disableV6NS logOutput logLevel ctl n ty = do
   (putLines, flushLog, loops, cxt) <- setup disableV6NS logOutput logLevel
   mapM_ forkIO $ loops
@@ -38,12 +37,10 @@ setup disableV6NS logOutput logLevel = do
   cxt <- Iterative.newEnv putLines disableV6NS ucache tcache
   return (putLines, flush, [logLoop], cxt)
 
-resolve :: Env -> IterativeControls -> String -> TYPE -> IO (Either QueryError DNSMessage)
+resolve :: Env -> IterativeControls -> String -> TYPE -> IO (Either String DNSMessage)
 resolve cxt ictl n ty =
-  fmap toMessage <$>
-  Iterative.runDNSQuery (Iterative.replyResult (fromString n) ty) cxt ictl
+  toMessage <$>
+  Iterative.runDNSQuery (Iterative.replyResult domain ty) cxt ictl
   where
-    toMessage (rc, ans, auth) = defaultResponse { DNS.header = h { DNS.flags = f }, DNS.answer = ans, DNS.authority = auth }
-      where
-        h = DNS.header defaultResponse
-        f = (DNS.flags h) { DNS.rcode = rc }
+    domain = fromString n
+    toMessage er = Iterative.replyMessage er 0 {- dummy id -} [Question domain ty classIN]

--- a/dnsext-full-resolver/dug/FullResolve.hs
+++ b/dnsext-full-resolver/dug/FullResolve.hs
@@ -14,21 +14,22 @@ import DNS.Types
 fullResolve :: Bool
             -> Log.Output
             -> Log.Level
+            -> Log.DemoFlag
             -> IterativeControls
             -> String
             -> TYPE
             -> IO (Either String DNSMessage)
-fullResolve disableV6NS logOutput logLevel ctl n ty = do
-  (putLines, flushLog, loops, cxt) <- setup disableV6NS logOutput logLevel
+fullResolve disableV6NS logOutput logLevel logDemo ctl n ty = do
+  (putLines, flushLog, loops, cxt) <- setup disableV6NS logOutput logLevel logDemo
   mapM_ forkIO $ loops
   out <- resolve cxt ctl n ty
   putLines Log.INFO ["--------------------"]
   flushLog
   return out
 
-setup :: Bool -> Log.Output -> Log.Level -> IO (Log.Level -> [String] -> IO (), IO (), [IO ()], Env)
-setup disableV6NS logOutput logLevel = do
-  (logLoop, putLines, _, flush) <- Log.new (Log.outputHandle logOutput) logLevel
+setup :: Bool -> Log.Output -> Log.Level -> Log.DemoFlag -> IO (Log.Level -> [String] -> IO (), IO (), [IO ()], Env)
+setup disableV6NS logOutput logLevel logDemo = do
+  (logLoop, putLines, _, flush) <- Log.new (Log.outputHandle logOutput) logLevel logDemo
   tcache@(getSec, _) <- TimeCache.new
   let cacheConf = Cache.getDefaultStubConf (4 * 1024) 600 getSec
   memo <- Cache.getMemo cacheConf

--- a/dnsext-full-resolver/dug/dug.hs
+++ b/dnsext-full-resolver/dug/dug.hs
@@ -111,7 +111,7 @@ main = do
             ictl = flagAD . flagCD . flagDO $ defaultIterativeControls
         ex <- fullResolve optDisableV6NS Log.Stdout Log.INFO ictl dom typ
         case ex of
-          Left err -> fail $ show err
+          Left err -> fail err
           Right rs -> putStr $ pprResult rs
       else do
         t0 <- T.getUnixTime

--- a/dnsext-full-resolver/dug/dug.hs
+++ b/dnsext-full-resolver/dug/dug.hs
@@ -114,7 +114,8 @@ main = do
             flagCD = update requestCD setRequestCD tblFlagCD
             flagAD = update requestAD setRequestAD tblFlagAD
             ictl = flagAD . flagCD . flagDO $ defaultIterativeControls
-        ex <- fullResolve optDisableV6NS Log.Stdout Log.INFO ictl dom typ
+            demoFlag = if optDemo then Log.EnableDemo else Log.DisableDemo
+        ex <- fullResolve optDisableV6NS Log.Stdout Log.INFO demoFlag ictl dom typ
         case ex of
           Left err -> fail err
           Right rs -> putStr $ pprResult rs

--- a/dnsext-full-resolver/dug/dug.hs
+++ b/dnsext-full-resolver/dug/dug.hs
@@ -37,6 +37,9 @@ options = [
   , Option ['i'] ["iterative"]
     (NoArg (\ opts -> opts { optIterative = True }))
     "resolve iteratively"
+  , Option [] ["demo"]
+    (NoArg (\ opts -> opts { optDemo = True }))
+    "demo logging outputs for iteratively resolve"
   , Option ['4'] ["ipv4"]
     (NoArg (\ opts -> opts { optDisableV6NS = True }))
     "disable IPv6 NS"
@@ -51,6 +54,7 @@ options = [
 data Options = Options {
     optHelp        :: Bool
   , optIterative   :: Bool
+  , optDemo        :: Bool
   , optDisableV6NS :: Bool
   , optPort        :: Maybe String
   , optDoX         :: ShortByteString
@@ -60,6 +64,7 @@ defaultOptions :: Options
 defaultOptions    = Options {
     optHelp        = False
   , optIterative   = False
+  , optDemo        = False
   , optDisableV6NS = False
   , optPort        = Nothing
   , optDoX         = "do53"

--- a/dnsext-full-resolver/mains/server.hs
+++ b/dnsext-full-resolver/mains/server.hs
@@ -15,6 +15,7 @@ data ServerOptions =
   ServerOptions
   { logOutput :: Log.Output
   , logLevel :: Log.Level
+  , logDemo :: Log.DemoFlag
   , maxKibiEntries :: Int
   , disableV6NS :: Bool
   , workers :: Int
@@ -32,6 +33,7 @@ defaultOptions =
   ServerOptions
   { logOutput = Log.Stdout
   , logLevel = Log.NOTICE
+  , logDemo = Log.DisableDemo
   , maxKibiEntries = 2 * 1024
   , disableV6NS = False
   , workers = 2
@@ -54,6 +56,9 @@ descs =
   , Option ['l'] ["log-level"]
     (ReqArg (\s opts -> readEither (map toUpper s) >>= \x -> return opts { logLevel = x }) "{WARN|NOTICE|INFO|DEBUG}")
     "server log-level"
+  , Option [] ["demo"]
+    (NoArg $ \opts -> return opts { logDemo = Log.EnableDemo })
+    "enable demo-log output"
   , Option ['M'] ["max-cache-entries"]
     (ReqArg (\s opts -> readIntWith (> 0) "max-cache-entries. not positive size" s >>= \x -> return opts { maxKibiEntries = x }) "POSITIVE_INTEGER")
     ("max K-entries in cache (1024 entries per 1). default is " ++ show (maxKibiEntries defaultOptions) ++ " K-entries")

--- a/dnsext-full-resolver/mains/server.hs
+++ b/dnsext-full-resolver/mains/server.hs
@@ -111,7 +111,7 @@ parseOptions args
 run :: ServerOptions -> IO ()
 run opts =
   Server.run
-  (fastLogger opts) (logOutput opts) (logLevel opts) (maxKibiEntries opts * 1024) (disableV6NS opts)
+  (fastLogger opts) (logOutput opts) (logLevel opts) (logDemo opts) (maxKibiEntries opts * 1024) (disableV6NS opts)
   (workers opts) (workerSharedQueue opts) (qsizePerWorker opts)
   (fromIntegral $ port opts) (bindHosts opts) (stdConsole opts)
 


### PR DESCRIPTION
Update to return ServFail for DNSSEC verification failure case,
and add DEMO logging outputs.

Examples are as follows:

----

Not Signed zone case:

```
 % ./dist/build/dug/dug --demo -i google.com. A +dnssec
query "." DNSKEY to [198.97.190.53,199.7.83.42,199.7.91.13,199.9.14.201]
query "." NS to [198.97.190.53,199.7.83.42,199.7.91.13,199.9.14.201]
query "com." A to [2001:500:2d::d,2001:500:2f::f,2001:500:9f::42,2001:500:a8::e]
delegation - verification success - RRSIG of DS: "." -> "com."
	"a.gtld-servers.net." ["192.5.6.30","2001:503:a83e::2:30"]
	"b.gtld-servers.net." ["192.33.14.30","2001:503:231d::2:30"]
	"c.gtld-servers.net." ["192.26.92.30","2001:503:83eb::30"]
	"d.gtld-servers.net." ["192.31.80.30","2001:500:856e::30"]
	"e.gtld-servers.net." ["192.12.94.30","2001:502:1ca1::30"]
	"f.gtld-servers.net." ["192.35.51.30","2001:503:d414::30"]
	"g.gtld-servers.net." ["192.42.93.30","2001:503:eea3::30"]
	"h.gtld-servers.net." ["192.54.112.30","2001:502:8cc::30"]
	"i.gtld-servers.net." ["192.43.172.30","2001:503:39c1::30"]
	"j.gtld-servers.net." ["192.48.79.30","2001:502:7094::30"]
	"k.gtld-servers.net." ["192.52.178.30","2001:503:d2d::30"]
	"l.gtld-servers.net." ["192.41.162.30","2001:500:d937::30"]
	"m.gtld-servers.net." ["192.55.83.30","2001:501:b1f9::30"]
query "com." DNSKEY to [2001:503:39c1::30,2001:503:83eb::30,2001:503:a83e::2:30,2001:503:d414::30]
query "google.com." A to [2001:500:d937::30,2001:501:b1f9::30,2001:502:8cc::30,2001:502:1ca1::30]
delegation - no DS, so no verify: "com." -> "google.com."
	"ns1.google.com." ["216.239.32.10","2001:4860:4802:32::a"]
	"ns2.google.com." ["216.239.34.10","2001:4860:4802:34::a"]
	"ns3.google.com." ["216.239.36.10","2001:4860:4802:36::a"]
	"ns4.google.com." ["216.239.38.10","2001:4860:4802:38::a"]
query "google.com." DS to [192.12.94.30,192.26.92.30,192.31.80.30,192.33.14.30]
query "google.com." A to [216.239.32.10,216.239.34.10,216.239.36.10,216.239.38.10]
no verification - no DS, "google.com." A
;; HEADER SECTION:
;Standard query, NoError, id: 0
;Flags: Recursion Desired, Recursion Available


;; QUESTION SECTION:
;google.com.		IN	A

;; ANSWER SECTION:
google.com.	300(5 mins)	IN	A	172.217.26.238

;; AUTHORITY SECTION:

;; ADDITIONAL SECTION:
```

----

Signed zone case:

```
 % ./dist/build/dug/dug --demo -i iij.ad.jp. A +dnssec
query "." DNSKEY to [2001:500:200::b,2001:503:c27::2:30,2001:503:ba3e::2:30,2001:7fd::1]
query "." NS to [2001:500:200::b,2001:503:c27::2:30,2001:503:ba3e::2:30,2001:7fd::1]
query "jp." A to [2001:500:2d::d,2001:500:2f::f,2001:500:9f::42,2001:500:a8::e]
delegation - verification success - RRSIG of DS: "." -> "jp."
	"a.dns.jp." ["203.119.1.1","2001:dc4::1"]
	"b.dns.jp." ["202.12.30.131","2001:dc2::1"]
	"c.dns.jp." ["156.154.100.5","2001:502:ad09::5"]
	"d.dns.jp." ["210.138.175.244","2001:240::53"]
	"e.dns.jp." ["192.50.43.53","2001:200:c000::35"]
	"f.dns.jp." ["150.100.6.8","2001:2f8:0:100::153"]
	"g.dns.jp." ["203.119.40.1"]
	"h.dns.jp." ["161.232.72.25","2a01:8840:1bc::25"]
query "jp." DNSKEY to [150.100.6.8,156.154.100.5,161.232.72.25,192.50.43.53]
query "ad.jp." A to [2001:2f8:0:100::153,2001:502:ad09::5,2001:dc2::1,2001:dc4::1]
no delegation: "jp." -> "ad.jp."
query "iij.ad.jp." A to [203.119.40.1,210.138.175.244,2001:200:c000::35,2001:240::53]
delegation - verification success - RRSIG of DS: "jp." -> "iij.ad.jp."
	"dns0.iij.ad.jp." ["210.130.0.5","2001:240::105"]
	"dns1.iij.ad.jp." ["210.130.1.5","2001:240::115"]
query "iij.ad.jp." DNSKEY to [210.130.0.5,210.130.1.5,2001:240::105,2001:240::115]
query "iij.ad.jp." A to [210.130.0.5,210.130.1.5,2001:240::105,2001:240::115]
verification success - RRSIG of "iij.ad.jp." A
;; HEADER SECTION:
;Standard query, NoError, id: 0
;Flags: Recursion Desired, Recursion Available


;; QUESTION SECTION:
;iij.ad.jp.		IN	A

;; ANSWER SECTION:
iij.ad.jp.	300(5 mins)	IN	A	202.232.2.191
iij.ad.jp.	300(5 mins)	IN	RRSIG	RD_RRSIG {rrsig_type = A, rrsig_pubalg = RSASHA256, rrsig_num_labels = 3, rrsig_ttl = 300(5 mins), rrsig_expiration = 1685200205, rrsig_inception = 1682608205, rrsig_key_tag = 44805, rrsig_zone = "iij.ad.jp.", rrsig_signature = \# 128 76acb44766c2fe641cc4fec1a56c7cac445f10663c704e44a0058149c899b9d220521b46370aeb0174c20df81f5ac1120f838fe1d3f1ba0138872821b2662db8d42b2ccb31c192c59a06d81a176d0526ed24e262745ad5cf9e6438d8d3270cef969608c4ebcdb9a9f00b655fb87f7c66a1869b50d0a358317981780a46304852}

;; AUTHORITY SECTION:

;; ADDITIONAL SECTION:
```

----

Verification failure case:

```
 % ./dist/build/dug/dug --demo -i brokendnssec.net. A +dnssec
query "." DNSKEY to [2001:503:c27::2:30,2001:503:ba3e::2:30,2001:7fd::1,2001:7fe::53]
query "." NS to [2001:503:c27::2:30,2001:503:ba3e::2:30,2001:7fd::1,2001:7fe::53]
query "net." A to [192.33.4.12,192.36.148.17,192.58.128.30,192.112.36.4]
delegation - verification success - RRSIG of DS: "." -> "net."
	"a.gtld-servers.net." ["192.5.6.30","2001:503:a83e::2:30"]
	"b.gtld-servers.net." ["192.33.14.30","2001:503:231d::2:30"]
	"c.gtld-servers.net." ["192.26.92.30","2001:503:83eb::30"]
	"d.gtld-servers.net." ["192.31.80.30","2001:500:856e::30"]
	"e.gtld-servers.net." ["192.12.94.30","2001:502:1ca1::30"]
	"f.gtld-servers.net." ["192.35.51.30","2001:503:d414::30"]
	"g.gtld-servers.net." ["192.42.93.30","2001:503:eea3::30"]
	"h.gtld-servers.net." ["192.54.112.30","2001:502:8cc::30"]
	"i.gtld-servers.net." ["192.43.172.30","2001:503:39c1::30"]
	"j.gtld-servers.net." ["192.48.79.30","2001:502:7094::30"]
	"k.gtld-servers.net." ["192.52.178.30","2001:503:d2d::30"]
	"l.gtld-servers.net." ["192.41.162.30","2001:500:d937::30"]
	"m.gtld-servers.net." ["192.55.83.30","2001:501:b1f9::30"]
query "net." DNSKEY to [2001:503:d2d::30,2001:503:231d::2:30,2001:503:39c1::30,2001:503:83eb::30]
query "brokendnssec.net." A to [192.33.14.30,192.35.51.30,192.41.162.30,192.42.93.30]
delegation - verification success - RRSIG of DS: "net." -> "brokendnssec.net."
	"carl.ns.cloudflare.com." []
	"cruz.ns.cloudflare.com." []
query "com." A to [192.5.5.241,192.33.4.12,192.36.148.17,192.58.128.30]
delegation - verification success - RRSIG of DS: "." -> "com."
	"a.gtld-servers.net." ["192.5.6.30","2001:503:a83e::2:30"]
	"b.gtld-servers.net." ["192.33.14.30","2001:503:231d::2:30"]
	"c.gtld-servers.net." ["192.26.92.30","2001:503:83eb::30"]
	"d.gtld-servers.net." ["192.31.80.30","2001:500:856e::30"]
	"e.gtld-servers.net." ["192.12.94.30","2001:502:1ca1::30"]
	"f.gtld-servers.net." ["192.35.51.30","2001:503:d414::30"]
	"g.gtld-servers.net." ["192.42.93.30","2001:503:eea3::30"]
	"h.gtld-servers.net." ["192.54.112.30","2001:502:8cc::30"]
	"i.gtld-servers.net." ["192.43.172.30","2001:503:39c1::30"]
	"j.gtld-servers.net." ["192.48.79.30","2001:502:7094::30"]
	"k.gtld-servers.net." ["192.52.178.30","2001:503:d2d::30"]
	"l.gtld-servers.net." ["192.41.162.30","2001:500:d937::30"]
	"m.gtld-servers.net." ["192.55.83.30","2001:501:b1f9::30"]
query "com." DNSKEY to [2001:502:7094::30,2001:503:d2d::30,2001:503:231d::2:30,2001:503:39c1::30]
query "cloudflare.com." A to [2001:503:39c1::30,2001:503:83eb::30,2001:503:a83e::2:30,2001:503:d414::30]
delegation - verification success - RRSIG of DS: "com." -> "cloudflare.com."
	"ns3.cloudflare.com." ["162.159.0.33","162.159.7.226","2400:cb00:2049:1::a29f:21","2400:cb00:2049:1::a29f:7e2"]
	"ns4.cloudflare.com." ["162.159.1.33","162.159.8.55","2400:cb00:2049:1::a29f:121","2400:cb00:2049:1::a29f:837"]
	"ns5.cloudflare.com." ["162.159.2.9","162.159.9.55","2400:cb00:2049:1::a29f:209","2400:cb00:2049:1::a29f:937"]
	"ns6.cloudflare.com." ["162.159.3.11","162.159.5.6","2400:cb00:2049:1::a29f:30b","2400:cb00:2049:1::a29f:506"]
	"ns7.cloudflare.com." ["162.159.4.8","162.159.6.6","2400:cb00:2049:1::a29f:408","2400:cb00:2049:1::a29f:606"]
query "cloudflare.com." DNSKEY to [162.159.5.6,162.159.6.6,162.159.7.226,162.159.8.55]
query "ns.cloudflare.com." A to [2400:cb00:2049:1::a29f:937,162.159.0.33,162.159.1.33,162.159.2.9]
no delegation: "cloudflare.com." -> "ns.cloudflare.com."
query "carl.ns.cloudflare.com." A to [162.159.3.11,162.159.4.8,162.159.5.6,162.159.6.6]
no delegation: "cloudflare.com." -> "carl.ns.cloudflare.com."
query "carl.ns.cloudflare.com." A to [162.159.1.33,162.159.2.9,162.159.3.11,162.159.4.8]
query "brokendnssec.net." DNSKEY to [173.245.59.106]
"brokendnssec.net.": verification error. dangling DS chain. DS exists, and DNSKEY does not exists
;; HEADER SECTION:
;Standard query, ServFail, id: 0
;Flags: Recursion Desired, Recursion Available


;; QUESTION SECTION:
;brokendnssec.net.		IN	A

;; ANSWER SECTION:

;; AUTHORITY SECTION:

;; ADDITIONAL SECTION:
```
