### PR TITLE
got DecodeError for TCP fallback case in dug

### DIFF
--- a/dnsext-do53/DNS/Do53/IO.hs
+++ b/dnsext-do53/DNS/Do53/IO.hs
@@ -56,7 +56,8 @@ recvVC lim recvN = do
     (l2,b2) <- recvManyNN recvN 2
     when (l2 /= 2) $ E.throwIO $ DecodeError "length is broken"
     let len = decodeVCLength $ BS.concat b2
-    when (len > lim) $ E.throwIO $ DecodeError "length is over the limit"
+    when (len > lim) $ E.throwIO $ DecodeError
+      $ "length is over the limit: should be len <= lim, but (len: " ++ show len ++ ") > (lim: " ++ show lim ++ ") "
     (len', bss) <- recvManyNN recvN len
     case compare len' len of
       LT -> E.throwIO $ DecodeError "message length is not enough"

--- a/dnsext-full-resolver/dug/Operation.hs
+++ b/dnsext-full-resolver/dug/Operation.hs
@@ -26,7 +26,7 @@ operate mserver port dox domain typ controls = do
         resolver = case makeResolver dox lim Nothing of
           Just r -> r
           Nothing -> let retry = DNS.lconfRetry conf
-                     in udpTcpResolver lim retry
+                     in udpTcpResolver retry lim
     withLookupConfAndResolver conf resolver $ \env -> do
         let q = Question (DNS.fromRepresentation domain) typ DNS.classIN
         DNS.lookupRaw env q


### PR DESCRIPTION
The `limit` parameter is used only for fallback to TCP.
The `retry` and `limit` arguments were mistakenly swapped, resulting in the following error:

```
 % ./dist/build/dug/dug @a.in-addr-servers.arpa. in-addr.arpa. DNSKEY +dnssec
dug: user error (DecodeError "length is over the limit")
```
