### PR TITLE
apply newtypes of integer type

### DIFF
--- a/dnsext-do53/DNS/Do53/IO.hs
+++ b/dnsext-do53/DNS/Do53/IO.hs
@@ -56,7 +56,7 @@ recvVC lim recvN = do
     (l2,b2) <- recvManyNN recvN 2
     when (l2 /= 2) $ E.throwIO $ DecodeError "length is broken"
     let len = decodeVCLength $ BS.concat b2
-    when (len > lim) $ E.throwIO $ DecodeError
+    when (fromIntegral len > lim) $ E.throwIO $ DecodeError
       $ "length is over the limit: should be len <= lim, but (len: " ++ show len ++ ") > (lim: " ++ show lim ++ ") "
     (len', bss) <- recvManyNN recvN len
     case compare len' len of

--- a/dnsext-do53/DNS/Do53/Internal.hs
+++ b/dnsext-do53/DNS/Do53/Internal.hs
@@ -44,7 +44,7 @@ module DNS.Do53.Internal (
     -- * Misc
   , checkRespM
   , UDPRetry
-  , VCLimit
+  , VCLimit (..)
   , LookupEnv(..)
   , modifyLookupEnv
   , withLookupConfAndResolver

--- a/dnsext-do53/DNS/Do53/Types.hs
+++ b/dnsext-do53/DNS/Do53/Types.hs
@@ -81,7 +81,7 @@ defaultCacheConf = CacheConf 300 0 10
 
 ----------------------------------------------------------------
 
-newtype UDPRetry = UDPRetry Int deriving (Eq, Num)
+newtype UDPRetry = UDPRetry Int deriving (Eq, Num, Show)
 newtype VCLimit = VCLimit { unVCLimit :: Int } deriving (Eq, Ord, Num, Show)
 
 

--- a/dnsext-do53/DNS/Do53/Types.hs
+++ b/dnsext-do53/DNS/Do53/Types.hs
@@ -7,7 +7,7 @@ module DNS.Do53.Types (
     LookupConf(..)
   , defaultLookupConf
   , UDPRetry
-  , VCLimit (..)
+  , VCLimit (unVCLimit)
   , LookupEnv(..)
   -- ** Specifying DNS servers
   , Seeds(..)

--- a/dnsext-do53/DNS/Do53/Types.hs
+++ b/dnsext-do53/DNS/Do53/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- | Resolver related data types.
 module DNS.Do53.Types (
@@ -6,7 +7,7 @@ module DNS.Do53.Types (
     LookupConf(..)
   , defaultLookupConf
   , UDPRetry
-  , VCLimit
+  , VCLimit (..)
   , LookupEnv(..)
   -- ** Specifying DNS servers
   , Seeds(..)
@@ -80,8 +81,9 @@ defaultCacheConf = CacheConf 300 0 10
 
 ----------------------------------------------------------------
 
-type UDPRetry = Int
-type VCLimit = Int
+newtype UDPRetry = UDPRetry Int deriving (Eq, Num)
+newtype VCLimit = VCLimit { unVCLimit :: Int } deriving (Eq, Ord, Num, Show)
+
 
 -- | Type for resolver configuration.
 --  Use 'defaultLookupConf' to create a new value.

--- a/dnsext-dox/DNS/DoX/HTTP2.hs
+++ b/dnsext-dox/DNS/DoX/HTTP2.hs
@@ -52,7 +52,7 @@ h2resolver ctx ident path lim ri@ResolvInfo{..} q qctl =
 doHTTP :: String -> Identifier -> ShortByteString -> VCLimit -> ResolvInfo -> Question -> QueryControls -> Client Result
 doHTTP tag ident path lim ri@ResolvInfo{..} q qctl sendRequest = sendRequest req $ \rsp -> do
     let recvHTTP = recvManyN $ getResponseBodyChunk rsp
-    (rx,bss) <- recvHTTP lim
+    (rx,bss) <- recvHTTP $ unVCLimit lim
     now <- getTime
     case decodeChunks now bss of
         Left  e       -> E.throwIO e

--- a/dnsext-dox/DNS/DoX/Stub.hs
+++ b/dnsext-dox/DNS/DoX/Stub.hs
@@ -58,7 +58,7 @@ lookupDoX conf domain typ = do
         Right Result{..} -> do
             let Reply{..} = resultReply
                 ss = sort (extractResourceData Answer replyDNSMessage) :: [RD_SVCB]
-            auto domain typ lim (lenvActions lenv) resultHostName ss
+            auto domain typ (unVCLimit lim) (lenvActions lenv) resultHostName ss
 
 auto :: HostName -> TYPE -> Int -> ResolvActions -> HostName -> [RD_SVCB] -> IO (Either DNSError Result)
 auto _ _ _ _ _ [] = return $ Left UnknownDNSError
@@ -72,7 +72,7 @@ auto domain typ lim actions ip0 ss0 = loop ss0
           Just alpns -> go $ alpn_names alpns
        where
          go [] = loop ss
-         go (alpn:alpns) = case makeResolver alpn lim Nothing of
+         go (alpn:alpns) = case makeResolver alpn (fromIntegral lim) Nothing of
            Nothing -> go alpns
            Just resolver  -> do
                mrply <- resolveDoX s alpn resolver


### PR DESCRIPTION
Apply newtype and GND Num instances, 
prevents issues like #86, where integer type arguments are passed incorrectly.