### PR TITLE
fix for sub-domain shared authoritative server

### DIFF
--- a/dnsext-full-resolver/DNS/Cache/Iterative.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative.hs
@@ -766,7 +766,8 @@ iterative_ dc nss0 (x:xs) =
          See the following document:
          QNAME Minimisation Examples: https://datatracker.ietf.org/doc/html/rfc9156#section-4 -}
       msg <- norec dnssecOK sas name A
-      lift $ delegationWithCache delegationZoneDomain delegationDNSKEY name msg
+      let sharedFallback = mayDelegation (subdomainShared dc nss name msg) (return . HasDelegation)
+      sharedFallback =<< lift (delegationWithCache delegationZoneDomain delegationDNSKEY name msg)
 
     step :: Delegation -> DNSQuery MayDelegation
     step nss = do

--- a/dnsext-full-resolver/DNS/Cache/Iterative.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative.hs
@@ -775,13 +775,7 @@ iterative_ dc nss0 (x:xs) =
             | nxc        =  return NoDelegation
             | otherwise  =  stepQuery nss
       md <- maybe (withNXC =<< lift lookupNX) return =<< lift (lookupDelegation name)
-      let fills d = do
-            filled@Delegation{..} <- fillDelegationDNSKEY dc =<< fillDelegationDS dc nss d
-            when (not (null delegationDS) && null delegationDNSKEY) $ do
-              lift $ logLn Log.NOTICE $ "iterative_.step: " ++ show delegationZoneDomain ++ ": " ++ "DS is not null, and DNSKEY is null"
-              lift $ clogLn Log.DEMO (Just Red) $ show delegationZoneDomain ++ ": verification error. dangling DS chain. DS exists, and DNSKEY does not exists"
-              throwDnsError DNS.ServerFailure
-            return filled
+      let fills d = fillsDNSSEC dc nss d
       mayDelegation (return NoDelegation) (fmap HasDelegation . fills) md
 
 -- If Nothing, it is a miss-hit against the cache.

--- a/dnsext-full-resolver/qtest/QuerySpec.hs
+++ b/dnsext-full-resolver/qtest/QuerySpec.hs
@@ -74,13 +74,13 @@ cacheStateSpec disableV6NS = describe "cache-state" $ do
     (_, cs) <- getResolveCache "iij.ad.jp." A
     check cs "ad.jp." NS `shouldSatisfy` isJust
 
-  it "sub-domain - nodata - ns" $ do
-    (_, cs) <- getResolveCache "1.1.1.1.in-addr.arpa." PTR
-    check cs "arpa." NS `shouldSatisfy` isJust
+  it "no zone sub-domain - nodata - ns" $ do
+    (_, cs) <- getResolveCache "iij.ad.jp." A
+    check cs "ad.jp." NS `shouldSatisfy` isJust
 
-  it "sub-domain - soa" $ do
-    (_, cs) <- getResolveCache "1.1.1.1.in-addr.arpa." PTR
-    check cs "arpa." SOA `shouldSatisfy` isJust
+  it "no zone sub-domain - soa" $ do
+    (_, cs) <- getResolveCache "iij.ad.jp." A
+    check cs "jp." SOA `shouldSatisfy` isJust
 
 querySpec :: Bool -> Bool -> Spec
 querySpec disableV6NS debug = describe "query" $ do

--- a/dnsext-full-resolver/qtest/QuerySpec.hs
+++ b/dnsext-full-resolver/qtest/QuerySpec.hs
@@ -3,7 +3,7 @@ module QuerySpec where
 import Test.Hspec
 
 import Control.Concurrent (threadDelay)
-import Data.Maybe (isJust)
+import Data.Maybe (isJust, isNothing)
 import Data.Either (isRight)
 import Data.String (fromString)
 import DNS.Types (TYPE(NS, A, AAAA, MX, CNAME, PTR, SOA))
@@ -81,6 +81,10 @@ cacheStateSpec disableV6NS = describe "cache-state" $ do
   it "no zone sub-domain - soa" $ do
     (_, cs) <- getResolveCache "iij.ad.jp." A
     check cs "jp." SOA `shouldSatisfy` isJust
+
+  it "shared child zone - ns" $ do
+    (_, cs) <- getResolveCache "1.1.1.1.in-addr.arpa." PTR
+    check cs "arpa." NS `shouldSatisfy` isNothing
 
 querySpec :: Bool -> Bool -> Spec
 querySpec disableV6NS debug = describe "query" $ do


### PR DESCRIPTION
~~draft PR. work in progress~~

Fixes the following problems in iterative lookups when a sub-domain is also managed by the same authoritative server (zone co-location).

* DS chain for DNSSEC between zone co-location was not validated
* Sub-domain side problem in case of zone co-location
    * Incorrect result record validation procedure
    * NS was cached with incorrect content

Fix #87.

```
 % dug -i in-addr.arpa. NS +dnssec
resolve-just: dc=0, ("in-addr.arpa.",NS)
...
delegationWithCache: "." -> "arpa.", no delegation
...
fillDelegationDS: "." -> "arpa.", fill delegation - verification success - RRSIG of DS
...
iterative: selected addresses:
	(2001:500:12::d0d,"in-addr.arpa.",A)
	(2001:500:2d::d,"in-addr.arpa.",A)
	(2001:500:2f::f,"in-addr.arpa.",A)
	(2001:500:9f::42,"in-addr.arpa.",A)
delegationWithCache: "arpa." -> "in-addr.arpa.", delegation - verification success - RRSIG of DS
...
cacheAnswer: verification success - RRSIG of "in-addr.arpa." NS
...
```


