### PR TITLE
Log level

### DIFF
--- a/dnsext-do53/DNS/Do53/Client.hs
+++ b/dnsext-do53/DNS/Do53/Client.hs
@@ -55,6 +55,7 @@ module DNS.Do53.Client (
     ractionTimeout,
     ractionGenId,
     ractionGetTime,
+    ractionLog,
     Reply,
 
     -- ** Query control

--- a/dnsext-do53/DNS/Do53/Do53.hs
+++ b/dnsext-do53/DNS/Do53/Do53.hs
@@ -18,9 +18,9 @@ import DNS.Do53.IO
 import DNS.Do53.Imports
 import DNS.Do53.Query
 import DNS.Do53.Types
+import qualified DNS.Log as Log
 import DNS.Types
 import DNS.Types.Decode
-import qualified DNS.Log as Log
 import qualified Data.ByteString as BS
 import Network.Socket (HostName, close)
 import qualified Network.UDP as UDP

--- a/dnsext-do53/DNS/Do53/Do53.hs
+++ b/dnsext-do53/DNS/Do53/Do53.hs
@@ -20,10 +20,10 @@ import DNS.Do53.Query
 import DNS.Do53.Types
 import DNS.Types
 import DNS.Types.Decode
+import qualified DNS.Log as Log
 import qualified Data.ByteString as BS
 import Network.Socket (HostName, close)
 import qualified Network.UDP as UDP
-import System.IO (hFlush, hPutStrLn, stderr)
 import System.IO.Error (annotateIOError)
 
 -- | Check response for a matching identifier and question.  If we ever do
@@ -112,8 +112,8 @@ udpResolver retry ri@ResolvInfo{..} q _qctl =
                         | w >= 16 = showHex w
                         | otherwise = ('0' :) . showHex w
                     dumpBS = ("\"" ++) . (++ "\"") . foldr (\w s -> "\\x" ++ showHex8 w s) "" . BS.unpack
-                debugLn $
-                    "udpResolver.getAnswer: decodeAt Left: " ++ rinfoHostName ++ ", " ++ dumpBS ans
+                ractionLog rinfoActions Log.DEBUG Nothing $
+                    ["udpResolver.getAnswer: decodeAt Left: ", rinfoHostName ++ ", ", dumpBS ans]
                 E.throwIO e
             Right msg
                 | checkResp q ident msg -> do
@@ -121,14 +121,11 @@ udpResolver retry ri@ResolvInfo{..} q _qctl =
                     return $ Reply msg tx rx
                 -- Just ignoring a wrong answer.
                 | otherwise -> do
-                    debugLn $
-                        "udpResolver.getAnswer: checkResp error: " ++ rinfoHostName ++ ", " ++ show msg
+                    ractionLog rinfoActions Log.DEBUG Nothing $
+                        ["udpResolver.getAnswer: checkResp error: ", rinfoHostName, ", ", show msg]
                     getAnswer ident recv tx
 
     open = UDP.clientSocket rinfoHostName (show rinfoPortNumber) True -- connected
-    debugLn s
-        | rinfoDebug = hPutStrLn stderr s *> hFlush stderr
-        | otherwise = pure ()
 
 ----------------------------------------------------------------
 

--- a/dnsext-do53/DNS/Do53/Types.hs
+++ b/dnsext-do53/DNS/Do53/Types.hs
@@ -48,6 +48,7 @@ import DNS.Do53.Id
 import DNS.Do53.Imports
 import DNS.Do53.Memo
 import DNS.Do53.Query
+import DNS.Log (PutLines)
 import System.Timeout (timeout)
 import Prelude
 
@@ -197,7 +198,6 @@ data ResolvInfo = ResolvInfo
     { rinfoHostName :: HostName
     , rinfoPortNumber :: PortNumber
     , rinfoActions :: ResolvActions
-    , rinfoDebug :: Bool
     }
 
 defaultResolvInfo :: ResolvInfo
@@ -206,7 +206,6 @@ defaultResolvInfo =
         { rinfoHostName = "127.0.0.1"
         , rinfoPortNumber = 53
         , rinfoActions = defaultResolvActions
-        , rinfoDebug = False
         }
 
 data Result = Result
@@ -234,6 +233,7 @@ data ResolvActions = ResolvActions
     , ractionGenId :: IO Identifier
     , ractionGetTime :: IO EpochTime
     , ractionSetSockOpt :: Socket -> IO ()
+    , ractionLog :: PutLines
     }
 
 defaultResolvActions :: ResolvActions
@@ -243,6 +243,7 @@ defaultResolvActions =
         , ractionGenId = singleGenId
         , ractionGetTime = getEpochTime
         , ractionSetSockOpt = rsso
+        , ractionLog = \_ _ _ -> return ()
         }
 
 rsso :: Socket -> IO ()

--- a/dnsext-do53/dnsext-do53.cabal
+++ b/dnsext-do53/dnsext-do53.cabal
@@ -54,6 +54,7 @@ library
         bytestring,
         containers,
         deepseq,
+        dnsext-log,
         dnsext-types,
         iproute >=1.3.2,
         mtl,

--- a/dnsext-full-resolver/DNS/Cache/Iterative.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative.hs
@@ -1055,7 +1055,7 @@ delegationWithCache
     :: Domain -> [RD_DNSKEY] -> Domain -> DNSMessage -> ContextT IO MayDelegation
 delegationWithCache zoneDom dnskeys dom msg = do
     -- There is delegation information only when there is a selectable NS
-    (verifyMsg, _verifyColor, dss, cacheDS) <- withSection rankedAuthority msg $ \rrs rank -> do
+    (verifyMsg, verifyColor, dss, cacheDS) <- withSection rankedAuthority msg $ \rrs rank -> do
         let (dsrds, dsRRs) = unzip $ rrListWith DS DNS.fromRData dom (,) rrs
         (RRset{..}, cacheDS) <- verifyAndCache dnskeys dsRRs (rrsigList dom DS rrs) rank
         let (verifyMsg, verifyColor)
@@ -1100,7 +1100,7 @@ delegationWithCache zoneDom dnskeys dom msg = do
             clogLn Log.DEMO Nothing $ ppDelegation (delegationNS x)
             return x
 
-    logLn Log.DEMO $ "delegationWithCache: " ++ domTraceMsg ++ ", " ++ verifyMsg
+    clogLn Log.DEMO verifyColor $ "delegationWithCache: " ++ domTraceMsg ++ ", " ++ verifyMsg
     maybe
         (notFound $> NoDelegation)
         (fmap HasDelegation . found)

--- a/dnsext-full-resolver/DNS/Cache/ServerMonitor.hs
+++ b/dnsext-full-resolver/DNS/Cache/ServerMonitor.hs
@@ -179,7 +179,7 @@ monitor stdConsole params cxt getsSizeInfo expires terminate = do
                 either (const $ return ()) (const loop)
                     =<< withWait
                         waitQuit
-                        (handle (logLn Log.NOTICE . ("monitor io-error: " ++) . show) step)
+                        (handle (logLn Log.WARN . ("monitor io-error: " ++) . show) step)
         loop
 
 console

--- a/dnsext-full-resolver/dug/FullResolve.hs
+++ b/dnsext-full-resolver/dug/FullResolve.hs
@@ -14,22 +14,21 @@ fullResolve
     :: Bool
     -> Log.Output
     -> Log.Level
-    -> Log.DemoFlag
     -> IterativeControls
     -> String
     -> TYPE
     -> IO (Either String DNSMessage)
-fullResolve disableV6NS logOutput logLevel logDemo ctl n ty = do
-    (putLines, terminate, cxt) <- setup disableV6NS logOutput logLevel logDemo
+fullResolve disableV6NS logOutput logLevel ctl n ty = do
+    (putLines, terminate, cxt) <- setup disableV6NS logOutput logLevel
     out <- resolve cxt ctl n ty
-    putLines Log.INFO Nothing ["--------------------"]
+    putLines Log.DEMO Nothing ["--------------------"]
     terminate
     return out
 
 setup
-    :: Bool -> Log.Output -> Log.Level -> Log.DemoFlag -> IO (Log.PutLines, IO (), Env)
-setup disableV6NS logOutput logLevel logDemo = do
-    (putLines, _, terminate) <- Log.new logOutput logLevel logDemo
+    :: Bool -> Log.Output -> Log.Level -> IO (Log.PutLines, IO (), Env)
+setup disableV6NS logOutput logLevel = do
+    (putLines, _, terminate) <- Log.new logOutput logLevel
     tcache@(getSec, _) <- TimeCache.new
     let cacheConf = Cache.getDefaultStubConf (4 * 1024) 600 getSec
     memo <- Cache.getMemo cacheConf

--- a/dnsext-full-resolver/dug/FullResolve.hs
+++ b/dnsext-full-resolver/dug/FullResolve.hs
@@ -19,23 +19,21 @@ fullResolve
     -> TYPE
     -> IO (Either String DNSMessage)
 fullResolve disableV6NS logOutput logLevel ctl n ty = do
-    (putLines, terminate, cxt) <- setup disableV6NS logOutput logLevel
+    (putLines, _, terminate) <- Log.new logOutput logLevel
+    cxt <- setup disableV6NS putLines
     out <- resolve cxt ctl n ty
     putLines Log.DEMO Nothing ["--------------------"]
     terminate
     return out
 
-setup
-    :: Bool -> Log.Output -> Log.Level -> IO (Log.PutLines, IO (), Env)
-setup disableV6NS logOutput logLevel = do
-    (putLines, _, terminate) <- Log.new logOutput logLevel
+setup :: Bool -> Log.PutLines -> IO Env
+setup disableV6NS putLines = do
     tcache@(getSec, _) <- TimeCache.new
     let cacheConf = Cache.getDefaultStubConf (4 * 1024) 600 getSec
     memo <- Cache.getMemo cacheConf
     let insert k ttl crset rank = Cache.insertWithExpiresMemo k ttl crset rank memo
         ucache = (insert, Cache.readMemo memo)
-    cxt <- Iterative.newEnv putLines disableV6NS ucache tcache
-    return (putLines, terminate, cxt)
+    Iterative.newEnv putLines disableV6NS ucache tcache
 
 resolve
     :: Env -> IterativeControls -> String -> TYPE -> IO (Either String DNSMessage)

--- a/dnsext-full-resolver/dug/dug.hs
+++ b/dnsext-full-resolver/dug/dug.hs
@@ -71,17 +71,17 @@ options =
     , Option
         []
         ["debug"]
-        (NoArg (\opts -> opts{optLogLevel= Log.DEBUG}))
+        (NoArg (\opts -> opts{optLogLevel = Log.DEBUG}))
         "set the log level to DEBUG"
     , Option
         []
         ["warn"]
-        (NoArg (\opts -> opts{optLogLevel= Log.WARN}))
+        (NoArg (\opts -> opts{optLogLevel = Log.WARN}))
         "set the log level to WARN"
     , Option
         []
         ["demo"]
-        (NoArg (\opts -> opts{optLogLevel= Log.DEMO}))
+        (NoArg (\opts -> opts{optLogLevel = Log.DEMO}))
         "set the log level to DEMO"
     ]
 

--- a/dnsext-full-resolver/dug/dug.hs
+++ b/dnsext-full-resolver/dug/dug.hs
@@ -51,11 +51,6 @@ options =
         (NoArg (\opts -> opts{optIterative = True}))
         "resolve iteratively"
     , Option
-        []
-        ["demo"]
-        (NoArg (\opts -> opts{optDemo = True}))
-        "demo logging outputs for iteratively resolve"
-    , Option
         ['4']
         ["ipv4"]
         (NoArg (\opts -> opts{optDisableV6NS = True}))
@@ -73,15 +68,30 @@ options =
             "auto|dot|doq|h2|h3"
         )
         "enable DoX"
+    , Option
+        []
+        ["debug"]
+        (NoArg (\opts -> opts{optLogLevel= Log.DEBUG}))
+        "set the log level to DEBUG"
+    , Option
+        []
+        ["warn"]
+        (NoArg (\opts -> opts{optLogLevel= Log.WARN}))
+        "set the log level to WARN"
+    , Option
+        []
+        ["demo"]
+        (NoArg (\opts -> opts{optLogLevel= Log.DEMO}))
+        "set the log level to DEMO"
     ]
 
 data Options = Options
     { optHelp :: Bool
     , optIterative :: Bool
-    , optDemo :: Bool
     , optDisableV6NS :: Bool
     , optPort :: Maybe String
     , optDoX :: ShortByteString
+    , optLogLevel :: Log.Level
     }
     deriving (Show)
 
@@ -90,10 +100,10 @@ defaultOptions =
     Options
         { optHelp = False
         , optIterative = False
-        , optDemo = False
         , optDisableV6NS = False
         , optPort = Nothing
         , optDoX = "do53"
+        , optLogLevel = Log.WARN
         }
 
 main :: IO ()
@@ -141,8 +151,7 @@ main = do
                 flagCD = update requestCD setRequestCD tblFlagCD
                 flagAD = update requestAD setRequestAD tblFlagAD
                 ictl = flagAD . flagCD . flagDO $ defaultIterativeControls
-                demoFlag = if optDemo then Log.EnableDemo else Log.DisableDemo
-            ex <- fullResolve optDisableV6NS Log.Stdout Log.INFO demoFlag ictl dom typ
+            ex <- fullResolve optDisableV6NS Log.Stdout optLogLevel ictl dom typ
             case ex of
                 Left err -> fail err
                 Right rs -> putStr $ pprResult rs

--- a/dnsext-full-resolver/mains/benchmark.hs
+++ b/dnsext-full-resolver/mains/benchmark.hs
@@ -27,7 +27,7 @@ defaultOptions :: BenchmarkOptions
 defaultOptions =
     BenchmarkOptions
         { logOutput = Log.Stdout
-        , logLevel = Log.NOTICE
+        , logLevel = Log.WARN
         , maxKibiEntries = 2 * 1024
         , noopMode = False
         , gplotMode = False

--- a/dnsext-full-resolver/mains/server.hs
+++ b/dnsext-full-resolver/mains/server.hs
@@ -18,7 +18,6 @@ import qualified DNS.Log as Log
 data ServerOptions = ServerOptions
     { logOutput :: Log.Output
     , logLevel :: Log.Level
-    , logDemo :: Log.DemoFlag
     , maxKibiEntries :: Int
     , disableV6NS :: Bool
     , workers :: Int
@@ -33,8 +32,7 @@ defaultOptions :: ServerOptions
 defaultOptions =
     ServerOptions
         { logOutput = Log.Stdout
-        , logLevel = Log.NOTICE
-        , logDemo = Log.DisableDemo
+        , logLevel = Log.WARN
         , maxKibiEntries = 2 * 1024
         , disableV6NS = False
         , workers = 2
@@ -67,11 +65,6 @@ descs =
             "{WARN|NOTICE|INFO|DEBUG}"
         )
         "server log-level"
-    , Option
-        []
-        ["demo"]
-        (NoArg $ \opts -> return opts{logDemo = Log.EnableDemo})
-        "enable demo-log output"
     , Option
         ['M']
         ["max-cache-entries"]
@@ -161,7 +154,6 @@ run opts =
     Server.run
         (logOutput opts)
         (logLevel opts)
-        (logDemo opts)
         (maxKibiEntries opts * 1024)
         (disableV6NS opts)
         (workers opts)


### PR DESCRIPTION
- Log level is now `WARN`, `DEMO` and `DEBUG` only.
- `dug` now has three options: "--warn", "--demo" and "--debug"
- Env var "DNSEXT_DEBUG" is obsoleted.
- `ractionLog` is defined.