### PR TITLE
dug: require initializing before parsing TYPE

### DIFF
--- a/dnsext-full-resolver/dug/dug.hs
+++ b/dnsext-full-resolver/dug/dug.hs
@@ -105,6 +105,9 @@ defaultOptions =
 
 main :: IO ()
 main = do
+    runInitIO $ do
+        addResourceDataForDNSSEC
+        addResourceDataForSVCB
     (args, Options{..}) <- getArgs >>= getArgsOpts
     when optHelp $ do
         putStr $ usageInfo help options
@@ -112,9 +115,6 @@ main = do
     let (at, plus, targets) = divide args
     (dom, typ) <- getDomTyp targets
     port <- getPort optPort optDoX
-    runInitIO $ do
-        addResourceDataForDNSSEC
-        addResourceDataForSVCB
     (putLines, _, terminate) <- Log.new Log.Stdout optLogLevel
     ----
     t0 <- T.getUnixTime

--- a/dnsext-full-resolver/dug/dug.hs
+++ b/dnsext-full-resolver/dug/dug.hs
@@ -106,6 +106,8 @@ defaultOptions =
 main :: IO ()
 main = do
     runInitIO $ do
+        {- Override the parser behavior to accept the extended TYPE.
+           Therefore, this action is required prior to reading the TYPE. -}
         addResourceDataForDNSSEC
         addResourceDataForSVCB
     (args, Options{..}) <- getArgs >>= getArgsOpts


### PR DESCRIPTION
error reading extra type

```
 % dug @1.1.1.1 _dns.resolver.arpa. svcb
Type svcb is not supported
```
