### PR TITLE
Simplify trace logs for demos

### DIFF
--- a/dnsext-full-resolver/DNS/Cache/Iterative.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative.hs
@@ -14,6 +14,7 @@ module DNS.Cache.Iterative (
 
     -- * testing
     runResolve,
+    runResolveExact,
     runResolveJust,
     rootHint,
     runIterative,

--- a/dnsext-full-resolver/DNS/Cache/Iterative/Delegation.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative/Delegation.hs
@@ -154,8 +154,7 @@ delegationWithCache zoneDom dnskeys dom msg = do
             clogLn Log.DEMO Nothing $ ppDelegation (delegationNS x)
             return x
 
-    lift . clogLn Log.DEMO verifyColor $
-        "delegationWithCache: " ++ domTraceMsg ++ ", " ++ verifyMsg
+    lift . clogLn Log.DEMO verifyColor $ verifyMsg ++ ": " ++ domTraceMsg
     raiseOnFailure
     lift . maybe (pure noDelegation) (fmap hasDelegation . found) $
         takeDelegationSrc nsps dss adds {- There is delegation information only when there is a selectable NS -}

--- a/dnsext-full-resolver/DNS/Cache/Iterative/Resolve.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative/Resolve.hs
@@ -177,7 +177,7 @@ resolveLogic logMark cnameHandler typeHandler n0 typ =
 {- CNAME のレコードを取得し、キャッシュする -}
 resolveCNAME :: Domain -> DNSQuery (DNSMessage, ([RRset], [RRset]))
 resolveCNAME bn = do
-    (msg, d) <- resolveJust bn CNAME
+    (msg, d) <- resolveExact bn CNAME
     (,) msg <$> cacheAnswer d bn CNAME msg
 
 {- 目的の TYPE のレコードの取得を試み、結果の DNSMessage を返す.
@@ -192,7 +192,7 @@ resolveTYPE
         , ([RRset], [RRset])
         ) {- result msg, cname, verified answer, verified authority -}
 resolveTYPE bn typ = do
-    (msg, delegation@Delegation{..}) <- resolveJust bn typ
+    (msg, delegation@Delegation{..}) <- resolveExact bn typ
     let checkTypeRR =
             when (any ((&&) <$> (== bn) . rrname <*> (== typ) . rrtype) $ DNS.answer msg) $
                 throwDnsError DNS.UnexpectedRDATA -- CNAME と目的の TYPE が同時に存在した場合はエラー

--- a/dnsext-full-resolver/DNS/Cache/Iterative/ResolveJust.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative/ResolveJust.hs
@@ -365,7 +365,7 @@ queryDS dnskeys ips dom = do
             rrsigs = rrsigList dom DS rrs
         (rrset, cacheDS) <- lift $ verifyAndCache dnskeys dsRRs rrsigs rank
         let verifyResult
-                | null dsrds = return (Right [], Nothing {- no DS, so no verify -})
+                | null dsrds = return (Right [], Just (Yellow, "no DS, so no verify"))
                 | rrsetVerified rrset =
                     lift cacheDS
                         *> return (Right dsrds, Just (Green, "verification success - RRSIG of DS"))

--- a/dnsext-full-resolver/DNS/Cache/Iterative/ResolveJust.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative/ResolveJust.hs
@@ -82,7 +82,7 @@ resolveJustDC dc n typ
         nss@Delegation{..} <- iterative_ dc root $ reverse $ DNS.superDomains n
         sas <- delegationIPs dc nss
         lift . logLn Log.DEMO . unwords $
-            ["resolve-just: query", show (n, typ), "selected addresses:"]
+            ["resolve-just: query", show (n, typ), "servers:"]
                 ++ [show sa | sa <- sas]
         let dnssecOK = not (null delegationDS) && not (null delegationDNSKEY)
         (,) <$> norec dnssecOK sas n typ <*> pure nss
@@ -243,7 +243,7 @@ iterative_ dc nss0 (x : xs) =
             "zone: " ++ show zone ++ ":\n" ++ ppDelegation delegationNS
         sas <- delegationIPs dc nss {- When the same NS information is inherited from the parent domain, balancing is performed by re-selecting the NS address. -}
         lift . logLn Log.DEMO . unwords $
-            ["iterative: query", show (name, A), "with selected addresses:"]
+            ["iterative: query", show (name, A), "servers:"]
                 ++ [show sa | sa <- sas]
         let dnssecOK = not (null delegationDS) && not (null delegationDNSKEY)
         {- Use `A` for iterative queries to the authoritative servers during iterative resolution.

--- a/dnsext-full-resolver/qtest/QuerySpec.hs
+++ b/dnsext-full-resolver/qtest/QuerySpec.hs
@@ -113,7 +113,7 @@ querySpec disableV6NS debug = describe "query" $ do
     cxt4 <- runIO $ newEnv (\_ _ _ -> pure ()) True ucache tcache
     let refreshRoot = runDNSQuery Iterative.refreshRoot cxt mempty
         runIterative ns n = Iterative.runIterative cxt ns (fromString n) mempty
-        runJust n ty = Iterative.runResolveJust cxt (fromString n) ty mempty
+        runJust n ty = Iterative.runResolveExact cxt (fromString n) ty mempty
         runResolve n ty =
             (snd <$>)
                 <$> Iterative.runResolve cxt (fromString n) ty mempty
@@ -207,7 +207,7 @@ querySpec disableV6NS debug = describe "query" $ do
     it "resolve-just - delegation with aa" $ do
         -- `dig -4 @ns1.alibabadns.com. danuoyi.alicdn.com. A` has delegation authority section with aa flag
         result <-
-            Iterative.runResolveJust
+            Iterative.runResolveExact
                 cxt4
                 (fromString "sc02.alicdn.com.danuoyi.alicdn.com.")
                 A


### PR DESCRIPTION
```
 % dug --demo -i iij.ad.jp. +dnssec
...
iterative: query ("jp.",A) servers: 199.7.91.13 199.9.14.201 202.12.27.33 2001:500:1::53
...
delegation - verification success - RRSIG of DS: "." -> "jp."
...
iterative: query ("ad.jp.",A) servers: 2001:dc2::1 2001:dc4::1 2a01:8840:1bc::25 150.100.6.8
...
no delegation: "jp." -> "ad.jp."
...
iterative: query ("iij.ad.jp.",A) servers: 2001:200:c000::35 2001:240::53 2001:2f8:0:100::153 2001:502:ad09::5
...
delegation - verification success - RRSIG of DS: "jp." -> "iij.ad.jp."
...
resolve-just: query ("iij.ad.jp.",A) servers: 210.130.0.5 210.130.1.5 2001:240::105 2001:240::115
verification success - RRSIG of "iij.ad.jp." A
;; 51usec
...
```

This should fix #105
