### PR TITLE
Extend column limit to 132

### DIFF
--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -2,7 +2,7 @@
 indentation: 4
 
 # Max line length for automatic line breaking
-column-limit: 80
+column-limit: 132
 
 # Styling of arrows in type signatures (choices: trailing, leading, or leading-args)
 function-arrows: leading


### PR DESCRIPTION
I would like to alleviate excessive line breaking when indentation is deep due to large nesting caused by Haskell's complex syntax structure.

I heard that 132-column mode was also selectable on vt100 :smile: 