### PR TITLE
Status hack

### DIFF
--- a/dnsext-full-resolver/DNS/Cache/Server.hs
+++ b/dnsext-full-resolver/DNS/Cache/Server.hs
@@ -4,4 +4,5 @@ module DNS.Cache.Server (
     Status,
 ) where
 
+import DNS.Cache.Server.Types
 import DNS.Cache.Server.UDP

--- a/dnsext-full-resolver/DNS/Cache/Server.hs
+++ b/dnsext-full-resolver/DNS/Cache/Server.hs
@@ -1,8 +1,7 @@
 module DNS.Cache.Server (
     UdpServerConfig (..),
     udpServer,
-    PipelineStatus (..),
-    PipelineStatusList,
+    Status,
 ) where
 
 import DNS.Cache.Server.UDP

--- a/dnsext-full-resolver/DNS/Cache/Server.hs
+++ b/dnsext-full-resolver/DNS/Cache/Server.hs
@@ -2,7 +2,7 @@ module DNS.Cache.Server (
     UdpServerConfig (..),
     udpServer,
     PipelineStatus (..),
-    PLStatus,
+    PipelineStatusList,
 ) where
 
 import DNS.Cache.Server.UDP

--- a/dnsext-full-resolver/DNS/Cache/Server.hs
+++ b/dnsext-full-resolver/DNS/Cache/Server.hs
@@ -1,7 +1,7 @@
 module DNS.Cache.Server (
     UdpServerConfig (..),
     udpServer,
-    WorkerStatus (..),
+    PipelineStatus (..),
     PLStatus,
 ) where
 

--- a/dnsext-full-resolver/DNS/Cache/Server/Bench.hs
+++ b/dnsext-full-resolver/DNS/Cache/Server/Bench.hs
@@ -39,7 +39,7 @@ benchServer UdpServerConfig{..} _ True = do
     return (pipelines, writeQueue reqQ, readQueue resQ)
 benchServer udpconf env _ = do
     (workerPipelines, enqueueReq, dequeueRes) <-
-        getWorkers udpconf env
+        getPipelines udpconf env
             :: IO ([IO ([IO ()], WorkerStatus)], Request () -> IO (), IO (Response ()))
     (workers, _getsStatus) <- unzip <$> sequence workerPipelines
     return (workers, enqueueReq, dequeueRes)

--- a/dnsext-full-resolver/DNS/Cache/Server/Bench.hs
+++ b/dnsext-full-resolver/DNS/Cache/Server/Bench.hs
@@ -20,6 +20,7 @@ import DNS.Cache.Queue (
     readQueue,
     writeQueue,
  )
+import DNS.Cache.Server.Types
 import DNS.Cache.Server.UDP
 
 ----------------------------------------------------------------

--- a/dnsext-full-resolver/DNS/Cache/Server/Bench.hs
+++ b/dnsext-full-resolver/DNS/Cache/Server/Bench.hs
@@ -40,6 +40,6 @@ benchServer UdpServerConfig{..} _ True = do
 benchServer udpconf env _ = do
     (workerPipelines, enqueueReq, dequeueRes) <-
         getPipelines udpconf env
-            :: IO ([IO ([IO ()], PipelineStatus)], Request () -> IO (), IO (Response ()))
+            :: IO ([IO ([IO ()], IO Status)], Request () -> IO (), IO (Response ()))
     (workers, _getsStatus) <- unzip <$> sequence workerPipelines
     return (workers, enqueueReq, dequeueRes)

--- a/dnsext-full-resolver/DNS/Cache/Server/Bench.hs
+++ b/dnsext-full-resolver/DNS/Cache/Server/Bench.hs
@@ -40,6 +40,6 @@ benchServer UdpServerConfig{..} _ True = do
 benchServer udpconf env _ = do
     (workerPipelines, enqueueReq, dequeueRes) <-
         getPipelines udpconf env
-            :: IO ([IO ([IO ()], WorkerStatus)], Request () -> IO (), IO (Response ()))
+            :: IO ([IO ([IO ()], PipelineStatus)], Request () -> IO (), IO (Response ()))
     (workers, _getsStatus) <- unzip <$> sequence workerPipelines
     return (workers, enqueueReq, dequeueRes)

--- a/dnsext-full-resolver/DNS/Cache/Server/Bench.hs
+++ b/dnsext-full-resolver/DNS/Cache/Server/Bench.hs
@@ -32,7 +32,7 @@ benchServer
     -> Bool
     -> IO ([[IO ()]], Request () -> IO (), IO (Request ()))
 benchServer UdpServerConfig{..} _ True = do
-    let qsize = udp_queue_size_per_worker * udp_pipelines_per_socket
+    let qsize = udp_queue_size_per_pipeline * udp_pipelines_per_socket
     reqQ <- newQueue qsize
     resQ <- newQueue qsize
     let pipelines = replicate udp_pipelines_per_socket [forever $ writeQueue resQ =<< readQueue reqQ]

--- a/dnsext-full-resolver/DNS/Cache/Server/Types.hs
+++ b/dnsext-full-resolver/DNS/Cache/Server/Types.hs
@@ -1,0 +1,3 @@
+module DNS.Cache.Server.Types where
+
+type Status = [(String, Int)]

--- a/dnsext-full-resolver/DNS/Cache/Server/UDP.hs
+++ b/dnsext-full-resolver/DNS/Cache/Server/UDP.hs
@@ -97,7 +97,7 @@ getPipelines
     :: Show a
     => UdpServerConfig
     -> Env
-    -> IO ([IO ([IO ()], WorkerStatus)], Request a -> IO (), IO (Response a))
+    -> IO ([IO ([IO ()], PipelineStatus)], Request a -> IO (), IO (Response a))
 getPipelines udpconf@UdpServerConfig{..} env
     | udp_queue_size_per_pipeline <= 0 = do
         reqQ <- newQueueChan
@@ -133,7 +133,7 @@ getCacherWorkers
     -> wq (Response a)
     -> UdpServerConfig
     -> Env
-    -> IO ([IO ()], WorkerStatus)
+    -> IO ([IO ()], PipelineStatus)
 getCacherWorkers reqQ resQ UdpServerConfig{..} env = do
     (CntGet{..}, incs) <- newCounters
 
@@ -148,7 +148,7 @@ getCacherWorkers reqQ resQ UdpServerConfig{..} env = do
         resolvLoops = replicate udp_workers_per_pipeline resolvLoop
         loops = resolvLoops ++ [cachedLoop]
 
-        workerStatus = WorkerStatus reqQSize decQSize resQSize getHit' getMiss' getFailed'
+        workerStatus = PipelineStatus reqQSize decQSize resQSize getHit' getMiss' getFailed'
 
     return (loops, workerStatus)
   where
@@ -243,7 +243,7 @@ queueSize q = do
 
 ----------------------------------------------------------------
 
-data WorkerStatus = WorkerStatus
+data PipelineStatus = PipelineStatus
     { reqQSize :: IO (Int, Int)
     , decQSize :: IO (Int, Int)
     , resQSize :: IO (Int, Int)
@@ -252,7 +252,7 @@ data WorkerStatus = WorkerStatus
     , getFailed :: IO Int
     }
 
-type PLStatus = [WorkerStatus]
+type PLStatus = [PipelineStatus]
 
 data CntGet = CntGet
     { getHit' :: IO Int

--- a/dnsext-full-resolver/DNS/Cache/Server/UDP.hs
+++ b/dnsext-full-resolver/DNS/Cache/Server/UDP.hs
@@ -76,7 +76,7 @@ udpServer
     -> Env
     -> PortNumber
     -> IP
-    -> IO ([IO ()], PLStatus)
+    -> IO ([IO ()], PipelineStatusList)
 udpServer conf env port hostIP = do
     sock <- UDP.serverSocket (hostIP, port)
     let putLn lv = logLines_ env lv Nothing . (: [])
@@ -252,7 +252,7 @@ data PipelineStatus = PipelineStatus
     , getFailed :: IO Int
     }
 
-type PLStatus = [PipelineStatus]
+type PipelineStatusList = [PipelineStatus]
 
 data CntGet = CntGet
     { getHit' :: IO Int

--- a/dnsext-full-resolver/DNS/Cache/Server/UDP.hs
+++ b/dnsext-full-resolver/DNS/Cache/Server/UDP.hs
@@ -19,6 +19,7 @@ import Network.Socket (
 import qualified Network.UDP as UDP
 
 -- other packages
+import qualified DNS.Log as Log
 import UnliftIO (SomeException, handle)
 
 -- this package
@@ -33,7 +34,7 @@ import DNS.Cache.Queue (
     writeQueue,
  )
 import qualified DNS.Cache.Queue as Queue
-import qualified DNS.Log as Log
+import DNS.Cache.Server.Types
 
 ----------------------------------------------------------------
 
@@ -268,8 +269,6 @@ newCounters = do
         return (readIORef ref, atomicModifyIORef' ref (\x -> (x + 1, ())))
 
 ----------------------------------------------------------------
-
-type Status = [(String, Int)]
 
 getStatus :: IO (Int, Int) -> IO (Int, Int) -> IO (Int, Int) -> IO Int -> IO Int -> IO Int -> IO [(String, Int)]
 getStatus reqQSize decQSize resQSize getHit getMiss getFailed = do

--- a/dnsext-full-resolver/bowline/Config.hs
+++ b/dnsext-full-resolver/bowline/Config.hs
@@ -24,8 +24,8 @@ data Config = Config
     , cnf_disable_v6_ns :: Bool
     , cnf_udp_pipelines_per_socket :: Int
     , cnf_udp_workers_per_pipeline :: Int
-    , cnf_udp_worker_share_queue :: Bool
-    , cnf_udp_queue_size_per_worker :: Int
+    , cnf_udp_queue_size_per_pipeline :: Int
+    , cnf_udp_pipeline_share_queue :: Bool
     , cnf_udp_port :: Int
     , cnf_monitor_port :: Int
     , cnf_bind_addresses :: [String]
@@ -42,8 +42,8 @@ defaultConfig =
         , cnf_disable_v6_ns = False
         , cnf_udp_pipelines_per_socket = 2
         , cnf_udp_workers_per_pipeline = 8
-        , cnf_udp_worker_share_queue = True
-        , cnf_udp_queue_size_per_worker = 16
+        , cnf_udp_pipeline_share_queue = True
+        , cnf_udp_queue_size_per_pipeline = 16
         , cnf_udp_port = 53
         , cnf_monitor_port = 10023
         , cnf_bind_addresses = []
@@ -60,8 +60,8 @@ showConfig conf =
     , field' "max cache size" cnf_cache_size
     , field' "disable queries to IPv6 NS" cnf_disable_v6_ns
     , field' "pipelines per socket" cnf_udp_pipelines_per_socket
-    , field' "worker shared queue" cnf_udp_worker_share_queue
-    , field' "queue size per worker" cnf_udp_queue_size_per_worker
+    , field' "worker shared queue" cnf_udp_pipeline_share_queue
+    , field' "queue size per worker" cnf_udp_queue_size_per_pipeline
     , field' "DNS port" cnf_udp_port
     , field' "Monitor port" cnf_monitor_port
     ]
@@ -91,8 +91,8 @@ makeConfig def conf =
         , cnf_disable_v6_ns = get "disable-v6-ns" cnf_disable_v6_ns
         , cnf_udp_pipelines_per_socket = get "udp-pipelines-per-socket" cnf_udp_pipelines_per_socket
         , cnf_udp_workers_per_pipeline = get "udp-workers-per-pipeline" cnf_udp_workers_per_pipeline
-        , cnf_udp_worker_share_queue = get "udp-worker-share-queue" cnf_udp_worker_share_queue
-        , cnf_udp_queue_size_per_worker = get "udp-queue-size-per-worker" cnf_udp_queue_size_per_worker
+        , cnf_udp_queue_size_per_pipeline = get "udp-queue-size-per-pipeline" cnf_udp_queue_size_per_pipeline
+        , cnf_udp_pipeline_share_queue = get "udp-pipeline-share-queue" cnf_udp_pipeline_share_queue
         , cnf_udp_port = get "udp-port" cnf_udp_port
         , cnf_monitor_port = get "monitor-port" cnf_monitor_port
         , cnf_bind_addresses = get "bind-addresses" cnf_bind_addresses

--- a/dnsext-full-resolver/bowline/Monitor.hs
+++ b/dnsext-full-resolver/bowline/Monitor.hs
@@ -201,9 +201,9 @@ console conf env (pQSizeList, ucacheQSize, logQSize) terminate (issueQuit, waitQ
                 psize ("request queue " ++ index) reqQSize
                 psize ("decoded queue " ++ index) decQSize
                 psize ("response queue " ++ index) resQSize
-            | (i, workerStatusList) <- zip [0 :: Int ..] pQSizeList
+            | (i, pipelineStatus) <- zip [0 :: Int ..] pQSizeList
             , (j, PipelineStatus{..}) <-
-                zip [0 :: Int ..] workerStatusList
+                zip [0 :: Int ..] pipelineStatus
             , let index = show i ++ "," ++ show j
             ]
         psize "ucache queue" ucacheQSize
@@ -213,8 +213,8 @@ console conf env (pQSizeList, ucacheQSize, logQSize) terminate (issueQuit, waitQ
         ts <-
             sequence
                 [ (,,) <$> getHit <*> getMiss <*> getFailed
-                | workerStatusList <- pQSizeList
-                , PipelineStatus{..} <- workerStatusList
+                | pipelineStatus <- pQSizeList
+                , PipelineStatus{..} <- pipelineStatus
                 ]
         let hits = sum [hit | (hit, _, _) <- ts]
             replies = hits + sum [miss | (_, miss, _) <- ts]

--- a/dnsext-full-resolver/bowline/Monitor.hs
+++ b/dnsext-full-resolver/bowline/Monitor.hs
@@ -202,7 +202,7 @@ console conf env (pQSizeList, ucacheQSize, logQSize) terminate (issueQuit, waitQ
                 psize ("decoded queue " ++ index) decQSize
                 psize ("response queue " ++ index) resQSize
             | (i, workerStatusList) <- zip [0 :: Int ..] pQSizeList
-            , (j, WorkerStatus{..}) <-
+            , (j, PipelineStatus{..}) <-
                 zip [0 :: Int ..] workerStatusList
             , let index = show i ++ "," ++ show j
             ]
@@ -214,7 +214,7 @@ console conf env (pQSizeList, ucacheQSize, logQSize) terminate (issueQuit, waitQ
             sequence
                 [ (,,) <$> getHit <*> getMiss <*> getFailed
                 | workerStatusList <- pQSizeList
-                , WorkerStatus{..} <- workerStatusList
+                , PipelineStatus{..} <- workerStatusList
                 ]
         let hits = sum [hit | (hit, _, _) <- ts]
             replies = hits + sum [miss | (_, miss, _) <- ts]

--- a/dnsext-full-resolver/bowline/bowline.conf
+++ b/dnsext-full-resolver/bowline/bowline.conf
@@ -2,9 +2,9 @@ log-level: WARN
 cache-size: 2048
 disable-v6-ns: no
 udp-pipelines-per-socket: 2
-udp-workers-per-pipline: 8
-udp-worker-share-queue: yes
-udp-queue-size-per-worker: 16
+udp-workers-per-pipeline: 8
+udp-queue-size-per-pipeline: 16
+udp-pipeline-share-queue: yes
 udp-port: 53
 monitor-port: 10023
 bind-addresses: ::1,127.0.0.1

--- a/dnsext-full-resolver/bowline/bowline.hs
+++ b/dnsext-full-resolver/bowline/bowline.hs
@@ -2,7 +2,6 @@
 
 module Main where
 
-import Control.Concurrent (getNumCapabilities)
 import qualified DNS.Do53.Memo as Cache
 import qualified DNS.Log as Log
 import qualified DNS.SEC as DNS
@@ -33,8 +32,8 @@ run :: Config -> IO ()
 run conf@Config{..} = do
     DNS.runInitIO DNS.addResourceDataForDNSSEC
     env <- getEnv conf
-    (serverLoops, qsizes) <- getUdpServer udpconf env cnf_udp_port' cnf_bind_addresses
-    monLoops <- getMonitor env conf qsizes
+    (serverLoops, getStatuses) <- getUdpServer udpconf env cnf_udp_port' cnf_bind_addresses
+    monLoops <- getMonitor env conf $ concat getStatuses
     race_
         (foldr concurrently_ (return ()) serverLoops)
         (foldr concurrently_ (return ()) monLoops)
@@ -57,22 +56,21 @@ main = do
 
 ----------------------------------------------------------------
 
-getUdpServer :: UdpServerConfig -> Env -> PortNumber -> [HostName] -> IO ([IO ()], [PipelineStatusList])
+getUdpServer :: UdpServerConfig -> Env -> PortNumber -> [HostName] -> IO ([IO ()], [[IO Status]])
 getUdpServer conf env port hosts = do
     hostIPs <- getHostIPs hosts port
-    (loopsList, qsizes) <- unzip <$> mapM (udpServer conf env port) hostIPs
+    (loopsList, getStatuses) <- unzip <$> mapM (udpServer conf env port) hostIPs
     let pLoops = concat loopsList
 
-    return (pLoops, qsizes)
+    return (pLoops, getStatuses)
   where
     getHostIPs [] p = getAInfoIPs p
     getHostIPs hs _ = return $ map fromString hs
 
 ----------------------------------------------------------------
 
-getMonitor :: Env -> Config -> [PipelineStatusList] -> IO [IO ()]
+getMonitor :: Env -> Config -> [IO Status] -> IO [IO ()]
 getMonitor env conf qsizes = do
-    _caps <- getNumCapabilities -- fixme
     logLines_ env Log.WARN Nothing $ map ("params: " ++) $ showConfig conf
 
     let ucacheQSize = return (0, 0 {- TODO: update ServerMonitor to drop -})

--- a/dnsext-full-resolver/bowline/bowline.hs
+++ b/dnsext-full-resolver/bowline/bowline.hs
@@ -44,8 +44,8 @@ run conf@Config{..} = do
         UdpServerConfig
             cnf_udp_pipelines_per_socket
             cnf_udp_workers_per_pipeline
-            cnf_udp_queue_size_per_worker
-            cnf_udp_worker_share_queue
+            cnf_udp_queue_size_per_pipeline
+            cnf_udp_pipeline_share_queue
 
 main :: IO ()
 main = do

--- a/dnsext-full-resolver/bowline/bowline.hs
+++ b/dnsext-full-resolver/bowline/bowline.hs
@@ -57,7 +57,7 @@ main = do
 
 ----------------------------------------------------------------
 
-getUdpServer :: UdpServerConfig -> Env -> PortNumber -> [HostName] -> IO ([IO ()], [PLStatus])
+getUdpServer :: UdpServerConfig -> Env -> PortNumber -> [HostName] -> IO ([IO ()], [PipelineStatusList])
 getUdpServer conf env port hosts = do
     hostIPs <- getHostIPs hosts port
     (loopsList, qsizes) <- unzip <$> mapM (udpServer conf env port) hostIPs
@@ -70,7 +70,7 @@ getUdpServer conf env port hosts = do
 
 ----------------------------------------------------------------
 
-getMonitor :: Env -> Config -> [PLStatus] -> IO [IO ()]
+getMonitor :: Env -> Config -> [PipelineStatusList] -> IO [IO ()]
 getMonitor env conf qsizes = do
     _caps <- getNumCapabilities -- fixme
     logLines_ env Log.WARN Nothing $ map ("params: " ++) $ showConfig conf

--- a/dnsext-full-resolver/dnsext-full-resolver.cabal
+++ b/dnsext-full-resolver/dnsext-full-resolver.cabal
@@ -33,6 +33,7 @@ library
         DNS.Cache.Queue
         DNS.Cache.RootServers
         DNS.Cache.RootTrustAnchors
+        DNS.Cache.Server.Types
         DNS.Cache.Server.UDP
 
     default-language: Haskell2010

--- a/dnsext-full-resolver/utils/benchmark.hs
+++ b/dnsext-full-resolver/utils/benchmark.hs
@@ -187,7 +187,7 @@ runBenchmark conf udpconf@UdpServerConfig{..} noop gplot size = do
         else do
             putStrLn . ("capabilities: " ++) . show =<< getNumCapabilities
             putStrLn $ "pipelines: " ++ show udp_pipelines_per_socket
-            putStrLn $ "qsizePerWorker: " ++ show udp_queue_size_per_worker
+            putStrLn $ "qsizePerPipeline: " ++ show udp_queue_size_per_pipeline
             putStrLn . ("cache size: " ++) . show . Cache.size =<< getCache_ env
             putStrLn $ "requests: " ++ show size
             putStrLn $ "elapsed: " ++ show elapsed


### PR DESCRIPTION
This introducing UDP-independent status mechanism.
Currently the `status` command displays awkward status.
We should revisit this after TCP and DoX servers are added since we don't know what kind of status is necessary from them at this moment.

Should also fix #123.