### PR TITLE
Fix extra action called to supplelement with DS

### DIFF
--- a/dnsext-full-resolver/DNS/Cache/Iterative/Cache.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative/Cache.hs
@@ -171,8 +171,9 @@ cacheAnswer Delegation{..} dom typ msg
             lift cacheX
             let qinfo = show dom ++ " " ++ show typ
                 (verifyMsg, verifyColor, raiseOnVerifyFailure)
-                    | null delegationDS = ("no verification - no DS, " ++ qinfo, Just Yellow, pure ())
+                    | FilledDS [] <- delegationDS = ("no verification - no DS, " ++ qinfo, Just Yellow, pure ())
                     | rrsetVerified xRRset = ("verification success - RRSIG of " ++ qinfo, Just Green, pure ())
+                    | NotFilledDS o <- delegationDS = ("not consumed not-filled DS: case=" ++ show o ++ ", " ++ qinfo, Nothing, pure ())
                     | otherwise = ("verification failed - RRSIG of " ++ qinfo, Just Red, throwDnsError DNS.ServerFailure)
             lift $ clogLn Log.DEMO verifyColor verifyMsg
             raiseOnVerifyFailure

--- a/dnsext-full-resolver/DNS/Cache/Iterative/Delegation.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative/Delegation.hs
@@ -77,12 +77,14 @@ lookupDelegation dom = do
                     | otherwise -> [DEonlyNS ns {- the case both A and AAAA are miss-hit -}]
                 Just as -> as {- just return address records. null case is wrong cache, so return null to skip this NS -}
         noCachedV4NS es = disableV6NS && null (v4DEntryList es)
+
         fromDEs es
-            | noCachedV4NS es = Nothing
             {- all NS records for A are skipped under disableV6NS, so handle as miss-hit NS case -}
-            | otherwise =
-                (\des -> hasDelegation $ Delegation dom des [] []) <$> uncons es
-        {- Nothing case, all NS records are skipped, so handle as miss-hit NS case -}
+            | noCachedV4NS es = Nothing
+            --
+            {- Nothing case, all NS records are skipped, so handle as miss-hit NS case -}
+            | otherwise = (\des -> hasDelegation $ Delegation dom des (NotFilledDS CachedDelegation) []) <$> uncons es
+
         getDelegation :: ([ResourceRecord], a) -> ContextT IO (Maybe MayDelegation)
         getDelegation (rrs, _) = do
             {- NS cache hit -}

--- a/dnsext-full-resolver/DNS/Cache/Iterative/Helpers.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative/Helpers.hs
@@ -105,7 +105,7 @@ takeDelegationSrc nsps dss adds = do
     let nss = map fst (p : ps)
     ents <- uncons $ concatMap (uncurry dentries) $ rrnamePairs (sort nss) addgroups
     {- only data from delegation source zone. get DNSKEY from destination zone -}
-    return $ Delegation (rrname rr) ents dss []
+    return $ Delegation (rrname rr) ents (FilledDS dss) []
   where
     addgroups = groupBy ((==) `on` rrname) $ sortOn ((,) <$> rrname <*> rrtype) adds
     dentries d [] = [DEonlyNS d]

--- a/dnsext-full-resolver/DNS/Cache/Iterative/ResolveJust.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative/ResolveJust.hs
@@ -226,6 +226,7 @@ runIterative cxt sa n cd = runDNSQuery (iterative sa n) cxt cd
 
 -- $setup
 -- >>> :set -XOverloadedStrings
+-- >>> :set -Wno-incomplete-uni-patterns
 -- >>> import System.IO
 -- >>> import qualified DNS.Types.Opaque as Opaque
 -- >>> import DNS.SEC


### PR DESCRIPTION
Fix conditions under which DS supplementing action is called

There are two cases in which the delegation information needs to be supplemented with DS

- When the delegation information is configured from the cache, but there is no cache of DS.
- When the child zones share the same authoritative server and the delegation information that should be available cannot be obtained.

Fixes a problem where the DS supplementing action is called in cases other than the above two cases.

This should fix #126.

"www.mew.org." example no longer outputs the `fill delegation` line.

```
...
delegation - verification success - RRSIG of DS: "." -> "org."
...
delegation - no DS, so no verify: "org." -> "mew.org."
...
no verification - no DS, "www.mew.org." A
;; 52usec

;; HEADER SECTION:
;Standard query, NoError, id: 0
;Flags: Recursion Desired, Recursion Available


;; QUESTION SECTION:
;www.mew.org.		IN	A

;; ANSWER SECTION:
www.mew.org.	3600(1 hour)	IN	A	202.238.220.92

;; AUTHORITY SECTION:

;; ADDITIONAL SECTION:
```
