### PR TITLE
Fix canonical-order of RData

### DIFF
--- a/dnsext-dnssec/DNS/SEC/Time.hs
+++ b/dnsext-dnssec/DNS/SEC/Time.hs
@@ -4,6 +4,8 @@ module DNS.SEC.Time where
 
 import DNS.SEC.Imports
 import DNS.Types.Internal
+
+import Data.String (IsString, fromString)
 import qualified Data.ByteString.Char8 as C8
 import Data.Int (Int64)
 import Data.UnixTime
@@ -16,6 +18,15 @@ toDNSTime = DNSTime
 
 instance Show DNSTime where
     show (DNSTime i32) = C8.unpack $ formatUnixTimeGMT webDateFormat $ UnixTime (CTime i32) 0
+
+{- read DNSTime from dig command output string -}
+readDigDNSTime :: String -> DNSTime
+readDigDNSTime s = DNSTime i
+  where
+    UnixTime (CTime i) _ = parseUnixTimeGMT (fromString "%Y%m%d%H%M%S") $ C8.pack s
+
+instance IsString DNSTime where
+  fromString = readDigDNSTime
 
 -- | Given a 32-bit circle-arithmetic DNS time, and the current absolute epoch
 -- time, return the epoch time corresponding to the DNS timestamp.

--- a/dnsext-dnssec/DNS/SEC/Verify/Verify.hs
+++ b/dnsext-dnssec/DNS/SEC/Verify/Verify.hs
@@ -126,10 +126,12 @@ verifyRRSIGwith RRSIGImpl{..} now dnskey@RD_DNSKEY{..} rrsig@RD_RRSIG{..} rrset_
 
 {- Canonical RR Ordering within an RRset
    https://datatracker.ietf.org/doc/html/rfc4034#section-6.3
-   Assumes same ( rrname, rrtype, rrclass, rrttl ).
-   Same order between RData and RR, under same ( rrname, rrtype, rrclass, rrttl ). -}
+   "RRs with the same owner name,
+    class, and type are sorted by treating the RDATA portion of the
+    canonical form of each RR as a left-justified unsigned octet sequence" -}
 sortRDataCanonical :: [ResourceRecord] -> [(SPut (), ResourceRecord)]
 sortRDataCanonical rrs =
+    {- sortOn "RDATA portion of the canonical form" without RDATA length -}
     map snd $ sortOn fst [(runSPut sput, (with16Length sput, rr)) | rr <- rrs, let sput = putRData' rr]
   where
     putRData' = putRData Canonical . rdata

--- a/dnsext-dnssec/DNS/SEC/Verify/Verify.hs
+++ b/dnsext-dnssec/DNS/SEC/Verify/Verify.hs
@@ -130,9 +130,9 @@ verifyRRSIGwith RRSIGImpl{..} now dnskey@RD_DNSKEY{..} rrsig@RD_RRSIG{..} rrset_
    Same order between RData and RR, under same ( rrname, rrtype, rrclass, rrttl ). -}
 sortRDataCanonical :: [ResourceRecord] -> [(SPut (), ResourceRecord)]
 sortRDataCanonical rrs =
-    map snd $ sortOn fst [(runSPut sput, (sput, rr)) | rr <- rrs, let sput = putLenRData rr]
+    map snd $ sortOn fst [(runSPut sput, (with16Length sput, rr)) | rr <- rrs, let sput = putRData' rr]
   where
-    putLenRData = with16Length . putRData Canonical . rdata
+    putRData' = putRData Canonical . rdata
 
 {- assume sorted input. generalized RRset with CPS -}
 canonicalRRsetSorted

--- a/dnsext-dnssec/DNS/SEC/Verify/Verify.hs
+++ b/dnsext-dnssec/DNS/SEC/Verify/Verify.hs
@@ -124,7 +124,7 @@ verifyRRSIGwith RRSIGImpl{..} now dnskey@RD_DNSKEY{..} rrsig@RD_RRSIG{..} rrset_
     good <- rrsigIVerify pubkey sig str
     unless good $ Left "verifyRRSIGwith: rejected on verification"
 
-{- Canonical RR Ordering within an RRset
+{- RFC 4034 Section 6.3: Canonical RR Ordering within an RRset
    https://datatracker.ietf.org/doc/html/rfc4034#section-6.3
    "RRs with the same owner name,
     class, and type are sorted by treating the RDATA portion of the

--- a/dnsext-dnssec/test/VerifySpec.hs
+++ b/dnsext-dnssec/test/VerifySpec.hs
@@ -30,6 +30,7 @@ spec = do
         it "ECDSA/P384" $ caseRRSIG ecdsaP384
         it "Ed25519" $ caseRRSIG ed25519
         it "Ed448" $ caseRRSIG ed448
+        it "some RData length" $ caseRRSIG someRDataLength
     describe "NSEC3 hash" $ do
         it "RFC7129 section5" $ caseNSEC3Hash nsec3HashRFC7129
     describe "verify NSEC3" $ do
@@ -605,6 +606,76 @@ ed448 =
             " Nmc0rgGKpr3GKYXcB1JmqqS4NYwhmechvJTqVzt3jR+Qy/lSLFoIk1L+9e3 \
             \ 9GPL+5tVzDPN3f9kAwiu8KCuPPjtl227ayaCZtRKZuJax7n9NuYlZJIusX0 \
             \ SOIOKBGzG+yWYtz1/jjbzl5GGkWvREUCUA "
+
+someRDataLength :: RRSIG_CASE
+someRDataLength =
+    ( ResourceRecord
+        { rrname = "1.in-addr.arpa."
+        , rrttl = 3600
+        , rrclass = classIN
+        , rrtype = DNSKEY
+        , rdata = key_rd
+        }
+    , [ ResourceRecord
+          { rrname = "1.in-addr.arpa."
+          , rrttl = 86400
+          , rrclass = classIN
+          , rrtype = NS
+          , rdata = rd_ns "apnic1.dnsnode.net."
+          }
+      , ResourceRecord
+          { rrname = "1.in-addr.arpa."
+          , rrttl = 86400
+          , rrclass = classIN
+          , rrtype = NS
+          , rdata = rd_ns "rirns.arin.net."
+          }
+      , ResourceRecord
+          { rrname = "1.in-addr.arpa."
+          , rrttl = 86400
+          , rrclass = classIN
+          , rrtype = NS
+          , rdata = rd_ns "ns2.apnic.net."
+          }
+      , ResourceRecord
+          { rrname = "1.in-addr.arpa."
+          , rrttl = 86400
+          , rrclass = classIN
+          , rrtype = NS
+          , rdata = rd_ns "ns3.lacnic.net."
+          }
+      , ResourceRecord
+          { rrname = "1.in-addr.arpa."
+          , rrttl = 86400
+          , rrclass = classIN
+          , rrtype = NS
+          , rdata = rd_ns "apnic.authdns.ripe.net."
+          }
+      ]
+    , ResourceRecord
+        { rrname = "1.in-addr.arpa."
+        , rrttl = 86400
+        , rrclass = classIN
+        , rrtype = RRSIG
+        , rdata = sig_rd
+        }
+    )
+  where
+    key_rd =
+      rd_dnskey'
+          256 3 13
+          " Mg+rz9zLYj22A5jXBeNUBJ0dgoFIsaJ0uxGMUQwe96SX5ZY3Rv7rsoT7 \
+          \ NxW3bz89yTEE3bsRC7ZNr3rJ6sXuvQ== "
+
+    sig_rd =
+      rd_rrsig'
+          NS 13 3
+          86400
+          "20230815144321" "20230731131321"
+          27138
+          "1.in-addr.arpa."
+          " orQelyK9FeIqXctGSJlavpVE3ZY1tR63RS6YXZE5wxLzj/yCo5ansthw \
+          \ vbr4qg0RNAblXlAObfERz7aE1e0z5A== "
 
 {- FOURMOLU_ENABLE -}
 


### PR DESCRIPTION
When sorting RRs in canonical order in RRset, the octet sequence should have been sorted excluding the length of RData.

Here is a test case to reproduce this issue
https://github.com/kazu-yamamoto/dnsext/commit/1120bcb01dc7a733d7a7cc17fe15881ac55062aa

This should fix #113 .
