### PR TITLE
Append signature data to cache

### DIFF
--- a/dnsext-do53/DNS/Do53/Cache.hs
+++ b/dnsext-do53/DNS/Do53/Cache.hs
@@ -5,9 +5,6 @@ module DNS.Do53.Cache (
     empty,
     null,
     lookupAlive,
-    lookup,
-    lookupEither,
-    takeRRSet,
     insert,
     expires,
     size,
@@ -36,6 +33,11 @@ module DNS.Do53.Cache (
     member,
     dump,
     dumpKeys,
+
+    -- * tests
+    lookup,
+    lookupEither,
+    takeRRSet,
 )
 where
 

--- a/dnsext-do53/DNS/Do53/Lookup.hs
+++ b/dnsext-do53/DNS/Do53/Lookup.hs
@@ -108,7 +108,7 @@ lookupCacheSection env@LookupEnv{..} q@Question{..} = do
             case mx of
                 Nothing -> notCached
                 Just (_, Left _) -> return $ Right [] {- NoData -}
-                Just (_, Right rs) -> return $ Right rs
+                Just (_, Right (rs, _)) -> return $ Right rs
   where
     notCached = do
         eres <- lookupRaw env q
@@ -142,7 +142,7 @@ cachePositive cconf c k now rss
     | otherwise = insertPositive cconf c k now v ttl
   where
     rds = map rdata rss
-    v = Right rds
+    v = Right (rds, Nothing)
     ttl = minimum $ map rrttl rss -- rss is non-empty
 
 insertPositive :: CacheConf -> Memo -> Key -> EpochTime -> Entry -> TTL -> IO ()

--- a/dnsext-do53/DNS/Do53/Lookup.hs
+++ b/dnsext-do53/DNS/Do53/Lookup.hs
@@ -101,14 +101,14 @@ lookupCacheSection
 lookupCacheSection env@LookupEnv{..} q@Question{..} = do
     nx <- lookupCache (keyForNX q) c
     case nx of
-        Just (_, Left _) -> return $ Left NameError
-        Just (_, Right _) -> return $ Left UnknownDNSError {- cache is inconsistent -}
+        Just (_, Negative{}) -> return $ Left NameError
+        Just (_, _) -> return $ Left UnknownDNSError {- cache is inconsistent -}
         Nothing -> do
             mx <- lookupCache q c
             case mx of
                 Nothing -> notCached
-                Just (_, Left _) -> return $ Right [] {- NoData -}
-                Just (_, Right (rs, _)) -> return $ Right rs
+                Just (_, Negative{}) -> return $ Right [] {- NoData -}
+                Just (_, crs) -> return $ Right $ crsRDatas crs
   where
     notCached = do
         eres <- lookupRaw env q
@@ -132,6 +132,7 @@ lookupCacheSection env@LookupEnv{..} q@Question{..} = do
                     Right rss -> do
                         cachePositive cconf c q now rss
                         return $ Right $ map rdata rss
+    crsRDatas = unCRSet (const []) id const
     toRR = filter (qtype `isTypeOf`) . answer
     (c, cconf) = fromJust lenvCache
 
@@ -142,7 +143,7 @@ cachePositive cconf c k now rss
     | otherwise = insertPositive cconf c k now v ttl
   where
     rds = map rdata rss
-    v = Right (rds, Nothing)
+    v = NotVerified rds
     ttl = minimum $ map rrttl rss -- rss is non-empty
 
 insertPositive :: CacheConf -> Memo -> Key -> EpochTime -> Entry -> TTL -> IO ()
@@ -155,7 +156,7 @@ insertPositive CacheConf{..} c k now v ttl = when (ttl /= 0) $ do
 cacheNegative :: CacheConf -> Memo -> Key -> EpochTime -> DNSMessage -> IO ()
 cacheNegative cconf c k now ans = case soas of
     [] -> return () -- does not cache anything
-    soa : _ -> insertNegative cconf c k now (Left $ rrname soa) $ rrttl soa
+    soa : _ -> insertNegative cconf c k now (Negative $ rrname soa) $ rrttl soa
   where
     soas = filter (SOA `isTypeOf`) $ authority ans
 

--- a/dnsext-do53/dnsext-do53.cabal
+++ b/dnsext-do53/dnsext-do53.cabal
@@ -56,6 +56,7 @@ library
         deepseq,
         dnsext-log,
         dnsext-types,
+        dnsext-dnssec,
         iproute >=1.3.2,
         mtl,
         network >=3.1.4,

--- a/dnsext-do53/test/CacheProp.hs
+++ b/dnsext-do53/test/CacheProp.hs
@@ -131,7 +131,7 @@ genCrsAssoc =
     , (AAAA, crset . (DNS.rd_aaaa <$>) <$> listOf1 (elements v6List))
     ]
   where
-    crset rd = Right (rd, Nothing)
+    crset rds = Cache.NotVerified rds
 
 toULString :: String -> Gen String
 toULString s = zipWith ulc <$> vectorOf (length s) arbitrary <*> pure s

--- a/dnsext-do53/test/CacheProp.hs
+++ b/dnsext-do53/test/CacheProp.hs
@@ -126,10 +126,12 @@ rankings = [RankAuthAnswer, RankAnswer, RankAdditional]
 
 genCrsAssoc :: [(TYPE, Gen CRSet)]
 genCrsAssoc =
-    [ (A, Right . (DNS.rd_a <$>) <$> listOf1 (elements v4List))
-    , (NS, Right . (DNS.rd_ns <$>) <$> listOf1 (elements nsList))
-    , (AAAA, Right . (DNS.rd_aaaa <$>) <$> listOf1 (elements v6List))
+    [ (A, crset . (DNS.rd_a <$>) <$> listOf1 (elements v4List))
+    , (NS, crset . (DNS.rd_ns <$>) <$> listOf1 (elements nsList))
+    , (AAAA, crset . (DNS.rd_aaaa <$>) <$> listOf1 (elements v6List))
     ]
+  where
+    crset rd = Right (rd, Nothing)
 
 toULString :: String -> Gen String
 toULString s = zipWith ulc <$> vectorOf (length s) arbitrary <*> pure s

--- a/dnsext-full-resolver/DNS/Cache/Iterative/Cache.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative/Cache.hs
@@ -122,8 +122,11 @@ rightRRset dom typ cls ttl (rds, msigs)
 
 ---
 
+{- lookup RRs without sigs -}
 lookupCache :: Domain -> TYPE -> ContextT IO (Maybe ([ResourceRecord], Ranking))
-lookupCache = withLookupCache Cache.lookup ""
+lookupCache dom typ = fmap noSigs <$> lookupRRset "" dom typ
+  where
+    noSigs (RRset{..}, rank) = ([ResourceRecord rrsName rrsType rrsClass rrsTTL rd | rd <- rrsRDatas], rank)
 
 -- | when cache has EMPTY result, lookup SOA data for top domain of this zone
 lookupCacheEither

--- a/dnsext-full-resolver/DNS/Cache/Iterative/Cache.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative/Cache.hs
@@ -5,7 +5,6 @@ module DNS.Cache.Iterative.Cache (
     lookupValid,
     lookupRRsetEither,
     lookupCache,
-    lookupCacheEither,
     cacheAnswer,
     cacheSection,
     cacheNoRRSIG,
@@ -127,14 +126,6 @@ lookupCache :: Domain -> TYPE -> ContextT IO (Maybe ([ResourceRecord], Ranking))
 lookupCache dom typ = fmap noSigs <$> lookupRRset "" dom typ
   where
     noSigs (RRset{..}, rank) = ([ResourceRecord rrsName rrsType rrsClass rrsTTL rd | rd <- rrsRDatas], rank)
-
--- | when cache has EMPTY result, lookup SOA data for top domain of this zone
-lookupCacheEither
-    :: String
-    -> Domain
-    -> TYPE
-    -> ContextT IO (Maybe (Either ([ResourceRecord], Ranking) [ResourceRecord], Ranking))
-lookupCacheEither = withLookupCache Cache.lookupEither
 
 cacheNoRRSIG :: [ResourceRecord] -> Ranking -> ContextT IO ()
 cacheNoRRSIG rrs0 rank = do

--- a/dnsext-full-resolver/DNS/Cache/Iterative/Cache.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative/Cache.hs
@@ -94,7 +94,7 @@ cacheNoRRSIG rrs0 rank = do
         insertRRSet <- asks insert_
         hrrs $ \dom typ cls ttl rds -> do
             plogLn Log.DEBUG . unwords $ ["RRset:", show (((dom, typ, cls), ttl), rank), ' ' : show rds]
-            liftIO $ insertRRSet (DNS.Question dom typ cls) ttl (Right rds) rank
+            liftIO $ insertRRSet (DNS.Question dom typ cls) ttl (Right (rds, Nothing)) rank
     (_, sortedRRs) = unzip $ SEC.sortRDataCanonical rrs0
 
 cacheSection :: [ResourceRecord] -> Ranking -> ContextT IO ()

--- a/dnsext-full-resolver/DNS/Cache/Iterative/Types.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative/Types.hs
@@ -2,6 +2,7 @@ module DNS.Cache.Iterative.Types (
     UpdateCache,
     TimeCache,
     Result,
+    ResultRRS,
     Env (..),
     RRset (..),
     DEntry (..),
@@ -159,3 +160,4 @@ data RRset = RRset
 
 {- response code, answer section, authority section -}
 type Result = (RCODE, [ResourceRecord], [ResourceRecord])
+type ResultRRS = (RCODE, [RRset], [RRset])

--- a/dnsext-full-resolver/DNS/Cache/Iterative/Verify.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative/Verify.hs
@@ -18,6 +18,7 @@ import System.Console.ANSI.Types
 
 -- dns packages
 import DNS.Do53.Memo (Ranking)
+import qualified DNS.Do53.Memo as Cache
 import DNS.SEC (
     RD_DNSKEY,
     RD_RRSIG (..),
@@ -158,9 +159,9 @@ cacheRRset
     -> MayVerifiedRRS
     -> ContextT IO ()
 cacheRRset rank dom typ cls ttl rds mv =
-    mayVerifiedRRS (doCache Nothing) (const $ pure ()) (doCache . Just) mv
+    mayVerifiedRRS (doCache $ Cache.NotVerified rds) (const $ pure ()) (doCache . Cache.Valid rds) mv
   where
-    doCache goodSigs = do
+    doCache crs = do
         insertRRSet <- asks insert_
         logLn Log.DEBUG $ "cacheRRset: " ++ show (((dom, typ, cls), ttl), rank) ++ "  " ++ show rds
-        liftIO $ insertRRSet (DNS.Question dom typ cls) ttl (Right (rds, goodSigs)) rank
+        liftIO $ insertRRSet (DNS.Question dom typ cls) ttl crs rank

--- a/dnsext-full-resolver/qtest/QuerySpec.hs
+++ b/dnsext-full-resolver/qtest/QuerySpec.hs
@@ -81,7 +81,7 @@ cacheStateSpec disableV6NS putLines = describe "cache-state" $ do
             (,) eresult . convert . Cache.dump <$> getCache_ cxt
         clookup cs n typ = lookup (fromString n, typ) cs
         check cs n typ = lookup (fromString n, typ) cs
-        nodata = maybe False (\(crset, _rank) -> either (const True) (const False) crset)
+        nodata = maybe False (\(crset, _rank) -> Cache.unCRSet (const True) (const False) (\_ _ -> False) crset)
 
     it "answer - a" $ do
         (_, cs) <- getResolveCache "iij.ad.jp." A


### PR DESCRIPTION
Change the cache to include DNSSEC validated signature data.
This change allows to recover RRset with signature data from the cache and to use the result for iterative lookups.
