### PR TITLE
NSEC/NSEC3 verifications dualing iterative lookups

### DIFF
--- a/dnsext-dnssec/DNS/SEC/Verify/NSECxRange.hs
+++ b/dnsext-dnssec/DNS/SEC/Verify/NSECxRange.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module DNS.SEC.Verify.NSECxRange where
+
+-- dnsext-types
+import DNS.Types
+
+-- this package
+import DNS.SEC.Imports
+import DNS.SEC.Types
+
+{- FOURMOLU_DISABLE -}
+data Impl range refined = forall bound . Ord bound =>
+    Impl
+    { nrangeTYPE :: TYPE
+    , nrangeTake :: ResourceRecord -> Maybe range
+    , nrangeRefine :: Domain -> range -> Either String refined
+    , nrangeLower :: refined -> bound
+    , nrangeUpper :: refined -> bound
+    }
+{- FOURMOLU_DISABLE -}
+
+---
+
+zipSigsets :: Impl range refined -> [ResourceRecord] -> (String -> a) -> ([(ResourceRecord, range, [(RD_RRSIG, TTL)])] -> a) -> a
+zipSigsets Impl{..} = zipSigsets_ nrangeTYPE nrangeTake
+
+zipSigsets_ :: TYPE -> (ResourceRecord -> Maybe r) -> [ResourceRecord] -> (String -> a) -> ([(ResourceRecord, r, [(RD_RRSIG, TTL)])] -> a) -> a
+zipSigsets_ nsecTy takeRange srrs leftK rightK = either leftK rightK $ zipSigs ranges sigsets
+  where
+    ranges = sortOn (rrname . fst) [(rr, range) | rr <- srrs, rrtype rr == nsecTy, Just range <- [takeRange rr]]
+    sigsets = [(rrn, map snd g) | g@((rrn, _) : _) <- groupBy ((==) `on` fst) $ sortOn fst sigs]
+    sigs =
+        [ (rrname rr, (rd, rrttl rr))
+        | rr <- srrs
+        , rrtype rr == RRSIG
+        , Just rd@RD_RRSIG{..} <- [fromRData $ rdata rr]
+        , rrsig_type == nsecTy
+        ]
+    zipSigs [] [] = Right []
+    zipSigs [] ((_, ss) : _) = errorOrphanRRSIG ss
+    zipSigs ((rr, _range) : _) [] = errorNoRRSIG rr
+    zipSigs ((rr, range) : rs) ((srrn, ss) : sgs) = do
+        let rrn = rrname rr
+        when (rrn < srrn) $ errorNoRRSIG rr
+        when (rrn > srrn) $ errorOrphanRRSIG ss
+        zs <- zipSigs rs sgs
+        Right $ (rr, range, ss) : zs
+    errorNoRRSIG rr = Left $ "NSECx.with-signed: " ++ show nsecTy ++ " without RRSIG found: " ++ show rr
+    errorOrphanRRSIG ss = Left $ "NSECx.with-signed: orphan RRSIGs found: " ++ show ss
+
+---
+
+uniqueSorted :: Show refined => Impl range refined -> [refined] -> Either String ()
+uniqueSorted Impl{..} = uniqueSorted_ nrangeLower nrangeUpper
+
+---
+
+-- $setup
+-- >>> :set -XTypeApplications
+
+-- |
+-- util to check unique and ordered range set of NSEC/NSEC3
+--
+-- >>> import Data.Either (isLeft)
+-- >>> uniqueSortedI = uniqueSorted_ @(Int,Int)
+-- >>> uniqueSortedI fst snd []
+-- Right ()
+-- >>> uniqueSortedI fst snd [(1,3)]
+-- Right ()
+-- >>> uniqueSortedI fst snd [(4,1)]
+-- Right ()
+-- >>> uniqueSortedI fst snd [(1,3),(3,4),(4,1)]
+-- Right ()
+-- >>> isLeft $ uniqueSortedI fst snd [(1,3),(2,4),(4,1)]
+-- True
+-- >>> isLeft $ uniqueSortedI fst snd [(1,3),(3,1),(4,1)]
+-- True
+uniqueSorted_ :: (Show r, Ord a) => (r -> a) -> (r -> a) -> [r] -> Either String ()
+uniqueSorted_ lower upper ranges = case reverse ranges of
+    [] -> Right ()
+    x : rs
+        | not goodOrder -> Left $ "unique-ranges: not good ordered range found: " ++ show notOrdered
+        | overlap -> Left $ "unique-ranges: overlapped range found: " ++ show overlapped
+        | otherwise -> Right ()
+      where
+        rotated = lower x > upper x {- only max range is allowed to be rotated -}
+        --
+        {- checking lower bound and upper bound is ordered -}
+        orders = (order x || rotated, x) : map ((,) <$> order <*> id) rs
+        notOrdered = map snd $ filter (not . fst) orders
+        goodOrder = all fst orders
+        --
+        {- checking ranges is not overlapped -}
+        nexts
+            | rotated = tail ranges ++ [head ranges]
+            | otherwise = tail ranges
+        overlaps = [(upper r > lower n, (r, n)) | (r, n) <- zip ranges nexts]
+        overlap = or $ map fst overlaps
+        overlapped = map snd $ filter fst overlaps
+  where
+    order r = lower r < upper r

--- a/dnsext-dnssec/DNS/SEC/Verify/Types.hs
+++ b/dnsext-dnssec/DNS/SEC/Verify/Types.hs
@@ -132,3 +132,53 @@ data NSEC_Result
     | NSECR_WildcardExpansion NSEC_WildcardExpansion
     | NSECR_WildcardNoData NSEC_WildcardNoData
     deriving (Show)
+
+---
+
+class NSECxWitness w where
+    witnessName :: w -> String
+    witnessDelegation :: w -> a -> a -> a
+
+---
+
+instance NSECxWitness NSEC3_NameError where
+    witnessName _ = "NSEC3 NameError"
+    witnessDelegation _ _ e = e
+
+instance NSECxWitness NSEC3_NoData where
+    witnessName _ = "NSEC3 NoData"
+    witnessDelegation _ _ e = e
+
+instance NSECxWitness NSEC3_UnsignedDelegation where
+    witnessName _ = "NSEC3 UnsignedDelegation"
+    witnessDelegation _ t _ = t
+
+instance NSECxWitness NSEC3_WildcardExpansion where
+    witnessName _ = "NSEC3 WildcardExpansion"
+    witnessDelegation _ _ e = e
+
+instance NSECxWitness NSEC3_WildcardNoData where
+    witnessName _ = "NSEC3 WildcardNoData"
+    witnessDelegation _ _ e = e
+
+---
+
+instance NSECxWitness NSEC_NameError where
+    witnessName _ = "NSEC NameError"
+    witnessDelegation _ _ e = e
+
+instance NSECxWitness NSEC_NoData where
+    witnessName _ = "NSEC NoData"
+    witnessDelegation _ _ e = e
+
+instance NSECxWitness NSEC_UnsignedDelegation where
+    witnessName _ = "NSEC UnsignedDelegation"
+    witnessDelegation _ t _ = t
+
+instance NSECxWitness NSEC_WildcardExpansion where
+    witnessName _ = "NSEC WildcardExpansion"
+    witnessDelegation _ _ e = e
+
+instance NSECxWitness NSEC_WildcardNoData where
+    witnessName _ = "NSEC WildcardNoData"
+    witnessDelegation _ _ e = e

--- a/dnsext-dnssec/DNS/SEC/Verify/Verify.hs
+++ b/dnsext-dnssec/DNS/SEC/Verify/Verify.hs
@@ -25,6 +25,7 @@ import DNS.SEC.Verify.EdDSA (ed25519, ed448)
 import qualified DNS.SEC.Verify.N3SHA as NSEC3
 import qualified DNS.SEC.Verify.NSEC as NSEC
 import qualified DNS.SEC.Verify.NSEC3 as NSEC3
+import qualified DNS.SEC.Verify.NSECxRange as NRange
 import DNS.SEC.Verify.RSA (rsaSHA1, rsaSHA256, rsaSHA512)
 import qualified DNS.SEC.Verify.SHA as DS
 import DNS.SEC.Verify.Types
@@ -312,6 +313,9 @@ hashNSEC3PARAM nsec3p domain =
 
 ---
 
+zipSigsNSEC3 :: [ResourceRecord] -> (String -> a) -> ([(ResourceRecord, NSEC3_Range, [(RD_RRSIG, TTL)])] -> a) -> a
+zipSigsNSEC3 = NRange.zipSigsets NSEC3.rangeImpl
+
 getNSEC3Result :: NSEC3.Logic a -> Domain -> [NSEC3_Range] -> Domain -> Either String a
 getNSEC3Result hl zone cs qname =
     withImpls $ \ps -> NSEC3.getResult hl zone [(c, hashNSEC3with impl nsec3) | (impl, c@(_, nsec3)) <- ps] qname
@@ -339,6 +343,11 @@ wildcardNoDataNSEC3 zone ranges qname qtype = getNSEC3Result (NSEC3.get_wildcard
 
 detectNSEC3 :: Domain -> [NSEC3_Range] -> Domain -> TYPE -> Either String NSEC3_Result
 detectNSEC3 zone ranges qname qtype = getNSEC3Result (NSEC3.detect qtype) zone ranges qname
+
+---
+
+zipSigsNSEC :: [ResourceRecord] -> (String -> a) -> ([(ResourceRecord, NSEC_Range, [(RD_RRSIG, TTL)])] -> a) -> a
+zipSigsNSEC = NRange.zipSigsets NSEC.rangeImpl
 
 ---
 

--- a/dnsext-dnssec/dnsext-dnssec.cabal
+++ b/dnsext-dnssec/dnsext-dnssec.cabal
@@ -39,6 +39,7 @@ library
         DNS.SEC.Verify.N3SHA
         DNS.SEC.Verify.NSEC
         DNS.SEC.Verify.NSEC3
+        DNS.SEC.Verify.NSECxRange
         DNS.SEC.Verify.Verify
 
     default-language: Haskell2010

--- a/dnsext-dnssec/test/VerifySpec.hs
+++ b/dnsext-dnssec/test/VerifySpec.hs
@@ -9,6 +9,7 @@ import DNS.SEC.Verify
 import DNS.Types
 import qualified DNS.Types.Opaque as Opaque
 import Data.ByteString (ByteString)
+import Data.List (sortOn)
 import Data.String (fromString)
 import Data.Word
 import Test.Hspec
@@ -761,7 +762,7 @@ caseNSEC3 ((zone, rds, qname, qtype), expect) = either expectationFailure (const
     result <- detectNSEC3 zone ranges qname qtype
     nsec3CheckResult result expect
   where
-    ranges = [(owner, nsec3) | (owner, rd) <- rds, Just nsec3 <- [fromRData rd]]
+    ranges = sortOn fst [(owner, nsec3) | (owner, rd) <- rds, Just nsec3 <- [fromRData rd]]
     getEach ex mz rs qn qt = case ex of
         N3Expect_NameError{} -> N3R_NameError <$> nameErrorNSEC3 mz rs qn
         N3Expect_NoData{} -> N3R_NoData <$> noDataNSEC3 mz rs qn qt
@@ -980,7 +981,7 @@ caseNSEC ((zone, rds, qname, qtype), expect) = either expectationFailure (const 
     result <- detectNSEC zone ranges qname qtype
     nsecCheckResult result expect
   where
-    ranges = [(owner, nsec) | (owner, rd) <- rds, Just nsec <- [fromRData rd]]
+    ranges = sortOn fst [(owner, nsec) | (owner, rd) <- rds, Just nsec <- [fromRData rd]]
     getEach ex z rs qn qt = case ex of
         NSEC_Expect_NameError{} -> NSECR_NameError <$> nameErrorNSEC z rs qn
         NSEC_Expect_NoData{} -> NSECR_NoData <$> noDataNSEC z rs qn qt

--- a/dnsext-full-resolver/DNS/Cache/Iterative/Cache.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative/Cache.hs
@@ -225,9 +225,13 @@ cacheNoDelegation d zone dnskeys dom msg
        However, without querying the NS of the CNAME destination,
        you cannot obtain the record of rank that can be used for the reply. -}
     cnRD rr = DNS.fromRData $ rdata rr :: Maybe DNS.RD_CNAME
-    nullCNAME = lift $ cacheSectionNegative zone dnskeys dom Cache.NX rankedAuthority msg []
+    nullCNAME = lift . cacheSectionNegative zone dnskeys dom Cache.NX rankedAuthority msg =<< witnessNameErr
     ncCNAME = cacheNoDataNS
+    {- not always possible to obtain NoData witness for NS
+       * no NSEC/NSEC3 records - ex. A record exists
+       * encloser NSEC/NSEC3 records for other than QNAME - ex. dig @ns1.dns-oarc.net. porttest.dns-oarc.net. A +dnssec -}
     cacheNoDataNS = lift $ cacheSectionNegative zone dnskeys dom NS rankedAuthority msg []
+    (_witnessNoDatas, witnessNameErr) = negativeWitnessActions (pure []) d dom A msg
     rcode = DNS.rcode $ DNS.flags $ DNS.header msg
 
 {- FOURMOLU_DISABLE -}

--- a/dnsext-full-resolver/DNS/Cache/Iterative/ResolveJust.hs
+++ b/dnsext-full-resolver/DNS/Cache/Iterative/ResolveJust.hs
@@ -284,10 +284,10 @@ iterative_ dc nss0 (x : xs) =
         msg <- norec dnssecOK sas name A
         let withNoDelegation handler = mayDelegation handler (return . hasDelegation)
             sharedHandler = servsChildZone dc nss name msg
-            cacheHandler = cacheNoDelegation zone dnskeys name msg $> noDelegation
+            cacheHandler = cacheNoDelegation nss zone dnskeys name msg $> noDelegation
         delegationWithCache zone dnskeys name msg
             >>= withNoDelegation sharedHandler
-            >>= lift . withNoDelegation cacheHandler
+            >>= withNoDelegation cacheHandler
 
     step :: Delegation -> DNSQuery MayDelegation
     step nss = do

--- a/dnsext-full-resolver/qtest/QuerySpec.hs
+++ b/dnsext-full-resolver/qtest/QuerySpec.hs
@@ -194,9 +194,21 @@ querySpec disableV6NS putLines = describe "query" $ do
         printQueryError result
         checkResult result `shouldBe` NotEmpty DNS.NoErr
 
-    it "resolve-just - nx" $ do
+    it "resolve-just - nx NSEC" $ do
         result <- runJust "does-not-exist.dns-oarc.net." A
         checkResult result `shouldBe` Empty DNS.NameErr
+
+    it "resolve-just - nodata NSEC" $ do
+        result <- runJust "mail.dns-oarc.net." NS
+        checkResult result `shouldBe` Empty DNS.NoErr
+
+    it "resolve-just - nx NSEC3" $ do
+        result <- runJust "does-not-exist.iij.ad.jp." A
+        checkResult result `shouldBe` Empty DNS.NameErr
+
+    it "resolve-just - nodata NSEC3" $ do
+        result <- runJust "www.iij.ad.jp." NS
+        checkResult result `shouldBe` Empty DNS.NoErr
 
     it "resolve-just - nx on iterative" $ do
         result <- runJust "media-router-aol1.prod.media.yahoo.com." CNAME


### PR DESCRIPTION
In iterative search, NSEC/NSEC3 signatures are verified and negative responses are judged based on their range information.

The followings are examples of a typical search run.

```
 % dug --demo -i mail.dns-oarc.net. NS +dnssec
...
root-priming: verification success - RRSIG of NS: "."
...
delegation - verification success - RRSIG of DS: "." -> "net."
...
delegation - verification success - RRSIG of DS: "net." -> "dns-oarc.net."
...
nsec verification success - NSEC NoData: "mail.dns-oarc.net." NS
;; 108usec

;; HEADER SECTION:
;Standard query, NoError, id: 0
;Flags: Recursion Desired, Recursion Available


;; QUESTION SECTION:
;mail.dns-oarc.net.		IN	NS

;; ANSWER SECTION:

;; AUTHORITY SECTION:
dns-oarc.net.	3600(1 hour)	IN	SOA	RD_SOA {soa_mname = "ns1.dns-oarc.net.", soa_rname = "hostmaster@dns-oarc.net.", soa_serial = 2023083100, soa_refresh = 300(5 mins), soa_retry = 60(1 min), soa_expire = 604800(7 days), soa_minimum = 3600(1 hour)}
dns-oarc.net.	3600(1 hour)	IN	RRSIG	RD_RRSIG {rrsig_type = SOA, rrsig_pubalg = ECDSAP256SHA256, rrsig_num_labels = 2, rrsig_ttl = 14400(4 hours), rrsig_expiration = Thu, 14 Sep 2023 02:19:35 GMT, rrsig_inception = Thu, 31 Aug 2023 00:49:35 GMT, rrsig_key_tag = 6048, rrsig_zone = "dns-oarc.net.", rrsig_signature = \# 64 b1bb41451ba77709f556f709b00f24e5fc25d019c22c58a776c9b3ba7ffd71772e67f280fca46e5f3b9dfaffcc7616f58629389aef13c33203be58443b55b6e2}
mail.dns-oarc.net.	3600(1 hour)	IN	NSEC	RD_NSEC {nsecNextDomain = "maint.dns-oarc.net.", nsecTypes = [A,RRSIG,NSEC]}
mail.dns-oarc.net.	3600(1 hour)	IN	RRSIG	RD_RRSIG {rrsig_type = NSEC, rrsig_pubalg = ECDSAP256SHA256, rrsig_num_labels = 3, rrsig_ttl = 3600(1 hour), rrsig_expiration = Tue, 12 Sep 2023 21:51:32 GMT, rrsig_inception = Tue, 29 Aug 2023 20:21:32 GMT, rrsig_key_tag = 6048, rrsig_zone = "dns-oarc.net.", rrsig_signature = \# 64 165b150b0bea0a24903f6360fe5bb07f16364dfee8f5cb8d8871da4869842cb3e876f483b866e8426066bd966206882e9669fd4f96162cfa84ae92ea2e7ac59b}

;; ADDITIONAL SECTION:
```

```
 % dug --demo -i does-not-exist.iij.ad.jp. A +dnssec
...
root-priming: verification success - RRSIG of NS: "."
...
delegation - verification success - RRSIG of DS: "." -> "jp."
...
delegation - verification success - RRSIG of DS: "jp." -> "iij.ad.jp."
...
nsec verification success - NSEC3 NameError: "does-not-exist.iij.ad.jp." A
;; 91usec

;; HEADER SECTION:
;Standard query, NXDomain, id: 0
;Flags: Recursion Desired, Recursion Available


;; QUESTION SECTION:
;does-not-exist.iij.ad.jp.		IN	A

;; ANSWER SECTION:

;; AUTHORITY SECTION:
iij.ad.jp.	3600(1 hour)	IN	SOA	RD_SOA {soa_mname = "bh0.iij.ad.jp.", soa_rname = "postmaster@iij.ad.jp.", soa_serial = 1693411805, soa_refresh = 3600(1 hour), soa_retry = 1800(30 mins), soa_expire = 1209600(14 days), soa_minimum = 3600(1 hour)}
iij.ad.jp.	3600(1 hour)	IN	RRSIG	RD_RRSIG {rrsig_type = SOA, rrsig_pubalg = RSASHA256, rrsig_num_labels = 3, rrsig_ttl = 86400(1 day), rrsig_expiration = Fri, 29 Sep 2023 15:10:05 GMT, rrsig_inception = Wed, 30 Aug 2023 15:10:05 GMT, rrsig_key_tag = 63864, rrsig_zone = "iij.ad.jp.", rrsig_signature = \# 128 7895f65e047a70e11d87ff815cf030ddb0ce31d25616d880dfa606e49ce0a90a6922543b5b87cda19443dabbf4344ca11e6a463b342cc58a5107769f77685f954ac731ca69956616cf48c62e00df388da3f8bfb5574142be7cb521343c388b74c1bbf0d3d83695ca44e440a799298af31d563ea2b9714bddd33920721ff9170f}
EDUG0EGV4PEH1TQJ827IUOFF8CFM5RCL.iij.ad.jp.	3600(1 hour)	IN	NSEC3	RD_NSEC3 {nsec3_hashalg = SHA1, nsec3_flags = [OptOut], nsec3_iterations = 7, nsec3_salt = \# 8 220c7bb179ed3b1d, nsec3_next_hashed_owner_name = \# 20 73ed02271369ca2604eab4c5b0285d0eec01e9e4, nsec3_types = [A,TXT,RRSIG]}
EDUG0EGV4PEH1TQJ827IUOFF8CFM5RCL.iij.ad.jp.	3600(1 hour)	IN	RRSIG	RD_RRSIG {rrsig_type = NSEC3, rrsig_pubalg = RSASHA256, rrsig_num_labels = 4, rrsig_ttl = 3600(1 hour), rrsig_expiration = Fri, 29 Sep 2023 15:10:05 GMT, rrsig_inception = Wed, 30 Aug 2023 15:10:05 GMT, rrsig_key_tag = 63864, rrsig_zone = "iij.ad.jp.", rrsig_signature = \# 128 1b34b84527357097ec9b06c4675f67730b05a9f8ec850508c955199e0cfff7492415ba0f6b3394fabc3966909fb22430f5f8a009424eb67f950c8db47de21afffd57f7ae57d13f395a589de2486085dbbd1c80d8a5ae3f5972b63197196378666c6c3f7edfcdefd40ba729b4136ffec0da829c857ae8be2a549a0647d6c9f7c8}
G2T2L7KSIPD3J9NAG9Q0AFNRM33MF3KA.iij.ad.jp.	3600(1 hour)	IN	NSEC3	RD_NSEC3 {nsec3_hashalg = SHA1, nsec3_flags = [OptOut], nsec3_iterations = 7, nsec3_salt = \# 8 220c7bb179ed3b1d, nsec3_next_hashed_owner_name = \# 20 8215efa721d10b4a6c9818659f411c641dd739c6, nsec3_types = [A,MX,TXT,AAAA,RRSIG]}
G2T2L7KSIPD3J9NAG9Q0AFNRM33MF3KA.iij.ad.jp.	3600(1 hour)	IN	RRSIG	RD_RRSIG {rrsig_type = NSEC3, rrsig_pubalg = RSASHA256, rrsig_num_labels = 4, rrsig_ttl = 3600(1 hour), rrsig_expiration = Fri, 29 Sep 2023 15:10:05 GMT, rrsig_inception = Wed, 30 Aug 2023 15:10:05 GMT, rrsig_key_tag = 63864, rrsig_zone = "iij.ad.jp.", rrsig_signature = \# 128 a1f05084dd7d87f07b65b46010c9bb8b1cf3c7412d42776e9215453fae034080ba93cda8cdf93bd8bcbf286b8a2e82912cbbce24f69c9d7e8f171c7888bb6aa57caa55915d7659fdcb6554688f9a65fafd07342911c73bbb947eae784a87f12c9197012a9f4c7282e0d01ec29fb3e89a4d5217ecf4097da847fdf544ded6b262}
T7M1GBM2P9M9JLPON3K495ISGD46Q0EO.iij.ad.jp.	3600(1 hour)	IN	NSEC3	RD_NSEC3 {nsec3_hashalg = SHA1, nsec3_flags = [OptOut], nsec3_iterations = 7, nsec3_salt = \# 8 220c7bb179ed3b1d, nsec3_next_hashed_owner_name = \# 20 ea299819f61a3e88aebe43e7103fd9e7984d5eb9, nsec3_types = [A,NS,SOA,MX,TXT,AAAA,RRSIG,DNSKEY,NSEC3PARAM]}
T7M1GBM2P9M9JLPON3K495ISGD46Q0EO.iij.ad.jp.	3600(1 hour)	IN	RRSIG	RD_RRSIG {rrsig_type = NSEC3, rrsig_pubalg = RSASHA256, rrsig_num_labels = 4, rrsig_ttl = 3600(1 hour), rrsig_expiration = Fri, 29 Sep 2023 15:10:05 GMT, rrsig_inception = Wed, 30 Aug 2023 15:10:05 GMT, rrsig_key_tag = 63864, rrsig_zone = "iij.ad.jp.", rrsig_signature = \# 128 a47838c15436f4159c17f2abe6452bf3f580c660fd41d6db1d7141dc69ae95e6f5b5c31b94a0e8d0396421384385a32f3fe18b7080d3dfd2086c25ada6b8f0e76a2e86f1a9adea03f1653a543fedede019b163cdbf7d3316fce5782ed7f9c05e31854b4cf9ef4f21ae7033cb832ae2de6b9fb436148b86b49208cb5421984e6e}

;; ADDITIONAL SECTION:
```
