### PR TITLE
Time clean up

### DIFF
--- a/dnsext-bowline/bowline/Monitor.hs
+++ b/dnsext-bowline/bowline/Monitor.hs
@@ -35,7 +35,7 @@ import DNS.Iterative.Server (HostName, PortNumber)
 import qualified DNS.Log as Log
 import qualified DNS.RRCache as Cache
 import qualified DNS.Types as DNS
-import DNS.Types.Decode (EpochTime)
+import DNS.Types.Time (EpochTime)
 import qualified Network.Socket as S
 
 -- other packages

--- a/dnsext-dnssec/DNS/SEC/Imports.hs
+++ b/dnsext-dnssec/DNS/SEC/Imports.hs
@@ -34,7 +34,7 @@ import Data.Word
 import Numeric
 
 import DNS.Types (Domain, IsRepresentation (..))
-import DNS.Types.Decode (EpochTime)
+import DNS.Types.Time (EpochTime)
 
 unconsLabels :: Domain -> a -> (ShortByteString -> Domain -> a) -> a
 unconsLabels = unconsLabels_

--- a/dnsext-do53/DNS/Do53/Imports.hs
+++ b/dnsext-do53/DNS/Do53/Imports.hs
@@ -19,7 +19,7 @@ where
 
 import Control.Applicative
 import Control.Monad
-import DNS.Types.Decode (EpochTime)
+import DNS.Types.Time (EpochTime)
 import Data.Bits
 import Data.ByteString (ByteString)
 import Data.ByteString.Short (ShortByteString)

--- a/dnsext-do53/DNS/Do53/Types.hs
+++ b/dnsext-do53/DNS/Do53/Types.hs
@@ -41,7 +41,6 @@ module DNS.Do53.Types (
 where
 
 import DNS.Types
-import DNS.Types.Decode
 import Network.Socket (HostName, PortNumber, Socket)
 #ifdef mingw32_HOST_OS
 import Network.Socket (setSocketOption, SocketOption(..))

--- a/dnsext-iterative/DNS/Iterative/Imports.hs
+++ b/dnsext-iterative/DNS/Iterative/Imports.hs
@@ -44,4 +44,4 @@ import Data.Word
 import Numeric
 
 -- dns packages
-import DNS.Types.Decode (EpochTime)
+import DNS.Types.Time (EpochTime)

--- a/dnsext-iterative/DNS/Iterative/Server/Pipeline.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/Pipeline.hs
@@ -13,6 +13,7 @@ import qualified DNS.TAP.Schema as DNSTAP
 import qualified DNS.Types as DNS
 import qualified DNS.Types.Decode as DNS
 import qualified DNS.Types.Encode as DNS
+import DNS.Types.Time (EpochTime)
 
 -- other packages
 import qualified DNS.Log as Log
@@ -58,7 +59,7 @@ cacherLogic
     :: Env
     -> CntInc
     -> (ByteString -> IO ())
-    -> (DNS.EpochTime -> a -> Either DNS.DNSError DNS.DNSMessage)
+    -> (EpochTime -> a -> Either DNS.DNSError DNS.DNSMessage)
     -> (DNS.DNSMessage -> IO ())
     -> SocketProtocol
     -> SockAddr

--- a/dnsext-iterative/DNS/Iterative/Server/Pipeline.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/Pipeline.hs
@@ -13,7 +13,7 @@ import qualified DNS.TAP.Schema as DNSTAP
 import qualified DNS.Types as DNS
 import qualified DNS.Types.Decode as DNS
 import qualified DNS.Types.Encode as DNS
-import DNS.Types.Time (EpochTime)
+import DNS.Types.Time
 
 -- other packages
 import qualified DNS.Log as Log
@@ -78,8 +78,8 @@ cacherLogic env CntInc{..} send decode toResolver proto mysa peersa req = do
                     incHit
                     let bs = DNS.encode rspMsg
                     send bs
-                    now' <- currentSeconds_ env
-                    logDNSTAP_ env $ DNSTAP.composeMessage proto mysa peersa now' bs
+                    (s,ns) <- getCurrentTimeNsec
+                    logDNSTAP_ env $ DNSTAP.composeMessage proto mysa peersa s ns bs
                 Negative replyErr -> do
                     incFailed
                     logLn Log.WARN $
@@ -108,8 +108,8 @@ workerLogic env CntInc{..} send proto mysa peersa reqMsg = do
             incMiss
             let bs = DNS.encode rspMsg
             send bs
-            now' <- currentSeconds_ env
-            logDNSTAP_ env $ DNSTAP.composeMessage proto mysa peersa now' bs
+            (s,ns) <- getCurrentTimeNsec
+            logDNSTAP_ env $ DNSTAP.composeMessage proto mysa peersa s ns bs
         Left e -> do
             incFailed
             logLn Log.WARN $

--- a/dnsext-types/DNS/StateBinary/SGet.hs
+++ b/dnsext-types/DNS/StateBinary/SGet.hs
@@ -47,6 +47,7 @@ import qualified Data.IntMap as IM
 import DNS.StateBinary.Types
 import DNS.Types.Error
 import DNS.Types.Imports
+import DNS.Types.Time
 
 ----------------------------------------------------------------
 

--- a/dnsext-types/DNS/Types/Decode.hs
+++ b/dnsext-types/DNS/Types/Decode.hs
@@ -14,7 +14,6 @@
 -- network.
 module DNS.Types.Decode (
     -- * Decoding a single DNS message
-    EpochTime,
     decodeAt,
     decode,
 
@@ -47,6 +46,7 @@ import DNS.Types.Error
 import DNS.Types.Imports
 import DNS.Types.Message
 import DNS.Types.RData
+import DNS.Types.Time
 import DNS.Types.Type
 
 ----------------------------------------------------------------

--- a/dnsext-types/DNS/Types/Imports.hs
+++ b/dnsext-types/DNS/Types/Imports.hs
@@ -14,7 +14,6 @@ module DNS.Types.Imports (
     module Data.Typeable,
     module Data.Word,
     module Numeric,
-    EpochTime,
 ) where
 
 import Control.Applicative
@@ -23,7 +22,6 @@ import Data.Bits
 import Data.ByteString (ByteString)
 import Data.ByteString.Short (ShortByteString)
 import Data.Function
-import Data.Int (Int64)
 import Data.List
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Maybe
@@ -33,5 +31,3 @@ import Data.String
 import Data.Typeable
 import Data.Word
 import Numeric
-
-type EpochTime = Int64

--- a/dnsext-types/DNS/Types/Time.hs
+++ b/dnsext-types/DNS/Types/Time.hs
@@ -1,0 +1,21 @@
+module DNS.Types.Time (
+    EpochTime,
+    getCurrentTime,
+    getCurrentTimeNsec,
+) where
+
+import Data.Int (Int64)
+import Data.UnixTime
+import Foreign.C.Types (CTime (..))
+
+type EpochTime = Int64
+
+getCurrentTime :: IO EpochTime
+getCurrentTime = do
+    UnixTime (CTime tim) _ <- getUnixTime
+    return tim
+
+getCurrentTimeNsec :: IO (EpochTime, Int64)
+getCurrentTimeNsec = do
+    UnixTime (CTime tim) usec <- getUnixTime
+    return (tim, fromIntegral usec * 1000)

--- a/dnsext-types/dnsext-types.cabal
+++ b/dnsext-types/dnsext-types.cabal
@@ -26,6 +26,7 @@ library
         DNS.Types.Encode
         DNS.Types.Internal
         DNS.Types.Opaque
+        DNS.Types.Time
 
     other-modules:
         DNS.StateBinary
@@ -59,6 +60,7 @@ library
         containers,
         iproute >=1.3.2,
         mtl,
+        unix-time,
         word8
 
     if impl(ghc >=8)

--- a/dnsext-utils/DNS/RRCache/Managed.hs
+++ b/dnsext-utils/DNS/RRCache/Managed.hs
@@ -30,7 +30,7 @@ import DNS.RRCache.ReaperReduced
 import DNS.RRCache.Types
 import qualified DNS.RRCache.Types as Cache
 import DNS.Types (TTL)
-import DNS.Types.Decode (EpochTime)
+import DNS.Types.Time (EpochTime)
 
 data RRCacheConf = RRCacheConf
     { maxCacheSize :: Int

--- a/dnsext-utils/DNS/RRCache/Types.hs
+++ b/dnsext-utils/DNS/RRCache/Types.hs
@@ -65,6 +65,8 @@ import Data.Maybe (isJust)
 import Prelude hiding (lookup, null)
 
 -- others
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NE
 import Data.OrdPSQ (OrdPSQ)
 import qualified Data.OrdPSQ as PSQ
 
@@ -80,10 +82,8 @@ import DNS.Types (
     TTL,
  )
 import qualified DNS.Types as DNS
-import DNS.Types.Decode (EpochTime)
 import DNS.Types.Internal (TYPE (..))
-import Data.List.NonEmpty (NonEmpty (..))
-import qualified Data.List.NonEmpty as NE
+import DNS.Types.Time (EpochTime)
 
 ---
 

--- a/dnsext-utils/DNS/TAP/Schema.hs
+++ b/dnsext-utils/DNS/TAP/Schema.hs
@@ -42,6 +42,7 @@ module DNS.TAP.Schema (
 ) where
 
 import DNS.Types (DNSError (..), DNSMessage)
+import DNS.Types.Time (EpochTime)
 import qualified DNS.Types.Decode as DNS
 import qualified DNS.Types.Encode as DNS
 import qualified Data.ByteString as BS
@@ -127,7 +128,7 @@ composeMessage
     :: SocketProtocol
     -> SockAddr
     -> SockAddr
-    -> DNS.EpochTime
+    -> EpochTime
     -> ByteString
     -> Message
 composeMessage proto mysa peersa t bs =

--- a/dnsext-utils/DNS/TAP/Schema.hs
+++ b/dnsext-utils/DNS/TAP/Schema.hs
@@ -42,11 +42,12 @@ module DNS.TAP.Schema (
 ) where
 
 import DNS.Types (DNSError (..), DNSMessage)
-import DNS.Types.Time (EpochTime)
 import qualified DNS.Types.Decode as DNS
 import qualified DNS.Types.Encode as DNS
+import DNS.Types.Time (EpochTime)
 import qualified Data.ByteString as BS
 import qualified Data.IP as IP
+import Data.Int (Int64)
 import Network.ByteOrder
 import Network.Socket (SockAddr (..))
 
@@ -129,9 +130,10 @@ composeMessage
     -> SockAddr
     -> SockAddr
     -> EpochTime
+    -> Int64
     -> ByteString
     -> Message
-composeMessage proto mysa peersa t bs =
+composeMessage proto mysa peersa s ns bs =
     defaultMessage
         { messageSocketFamily     = toFamily peersa
         , messageSocketProtocol   = Just proto
@@ -139,8 +141,8 @@ composeMessage proto mysa peersa t bs =
         , messageResponseAddress  = toIP mysa
         , messageQueryPort        = toPort peersa
         , messageResponsePort     = toPort mysa
-        , messageResponseTimeSec  = Just $ fromIntegral t
-        , messageResponseTimeNsec = Just 0
+        , messageResponseTimeSec  = Just $ fromIntegral s
+        , messageResponseTimeNsec = Just $ fromIntegral ns
         , messageResponseMessage  = Just $ WireFt bs
         }
  where

--- a/dnsext-utils/DNS/TimeCache.hs
+++ b/dnsext-utils/DNS/TimeCache.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module DNS.TimeCache (
     TimeCache (..),
     newTimeCache,
@@ -6,7 +8,6 @@ module DNS.TimeCache (
 
 -- GHC packages
 import qualified Data.ByteString.Char8 as C8
-import Data.String (fromString)
 import Foreign.C.Types (CTime (..))
 
 -- other packages
@@ -19,7 +20,7 @@ import Control.AutoUpdate (
 import Data.UnixTime (UnixTime (..), formatUnixTime, getUnixTime)
 
 -- dnsext packages
-import DNS.Types.Decode (EpochTime)
+import DNS.Types.Time
 
 -- this package
 
@@ -53,14 +54,14 @@ mostOncePerSecond upd =
 noneTimeCache :: TimeCache
 noneTimeCache =
     TimeCache
-        { getTime = unixToEpoch <$> getUnixTime
+        { getTime = getCurrentTime
         , getTimeStr = getTimeShowS =<< getUnixTime
         }
 
 ---
 
 getTimeShowS :: UnixTime -> IO ShowS
-getTimeShowS ts = (++) . C8.unpack <$> formatUnixTime (fromString "%Y-%m-%d %H:%M:%S %Z") ts
+getTimeShowS ts = (++) . C8.unpack <$> formatUnixTime "%Y-%m-%d %H:%M:%S %Z" ts
 
 unixToEpoch :: UnixTime -> EpochTime
 unixToEpoch (UnixTime (CTime tim) _) = tim

--- a/dnsext-utils/test/CacheProp.hs
+++ b/dnsext-utils/test/CacheProp.hs
@@ -25,7 +25,7 @@ import Test.QuickCheck
 -- dnsext packages
 import DNS.Types (Domain, Seconds (..), TTL, TYPE (..))
 import qualified DNS.Types as DNS
-import DNS.Types.Decode (EpochTime)
+import DNS.Types.Time (EpochTime)
 
 -- this package
 import DNS.RRCache (


### PR DESCRIPTION
- Keep `TimeCache` as is (time case is used for performance)
- Provide `DNS.Types.Time` since `import DNS.Types.Decode (EpochTime)` is awkward
- Use nano second only for DNSTAP