### PR TITLE
fromBase32Hex fusion loop

### DIFF
--- a/dnsext-types/DNS/Types/Opaque/Internal.hs
+++ b/dnsext-types/DNS/Types/Opaque/Internal.hs
@@ -57,7 +57,7 @@ toBase32Hex :: Opaque -> ByteString
 toBase32Hex (Opaque o) = B32H.encode $ Short.fromShort o
 
 fromBase32Hex :: ByteString -> Either String Opaque
-fromBase32Hex = (Opaque . Short.toShort <$>) . B32H.decode
+fromBase32Hex = (Opaque <$>) . B32H.decode
 
 toBase64 :: Opaque -> ByteString
 toBase64 (Opaque o) = B64.encode $ Short.fromShort o


### PR DESCRIPTION
An issue raised in https://github.com/kazu-yamamoto/dnsext/issues/145#issuecomment-1751926230

Applying fusion loop to reduce allocation during decoding base32hex.

A comparison of before and after profile results is below.

----

before applying:

```
COST CENTRE           MODULE                      SRC                                          %time %alloc

fromBase32Hex         DNS.Types.Opaque.Internal   DNS/Types/Opaque/Internal.hs:60:1-58           2.3    6.2
```

----

after applying:

```
COST CENTRE           MODULE                      SRC                                          %time %alloc

fromBase32Hex         DNS.Types.Opaque.Internal   DNS/Types/Opaque/Internal.hs:60:1-42           0.3    1.3
```
