### PR TITLE
domain as vector of labels

### DIFF
--- a/dnsext-dnssec/DNS/SEC/Imports.hs
+++ b/dnsext-dnssec/DNS/SEC/Imports.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module DNS.SEC.Imports (
     ByteString,
     ShortByteString,
@@ -33,13 +35,10 @@ import Data.Typeable
 import Data.Word
 import Numeric
 
-import DNS.Types (Domain, IsRepresentation (..))
+import DNS.Types (Domain, unconsDomain)
 import DNS.Types.Time (EpochTime)
 
 unconsLabels :: Domain -> a -> (ShortByteString -> Domain -> a) -> a
-unconsLabels = unconsLabels_
-
-unconsLabels_ :: IsRepresentation a b => a -> c -> (b -> a -> c) -> c
-unconsLabels_ rep nothing just = case toWireLabels rep of
-    [] -> nothing
-    x : xs -> just x $ fromWireLabels xs
+unconsLabels d nothing just = case unconsDomain d of
+    Nothing -> nothing
+    Just (x, xs) -> just x $ xs

--- a/dnsext-dnssec/DNS/SEC/Verify/NSEC3.hs
+++ b/dnsext-dnssec/DNS/SEC/Verify/NSEC3.hs
@@ -299,5 +299,5 @@ n3RefineWithRanges zone ranges0 = do
 -- []
 zoneSubDomains :: Domain -> Domain -> [Domain]
 zoneSubDomains domain zone
-    | domain `isSubDomainOf` zone = takeWhile (/= zone) (superDomains domain ++ [fromString "."]) ++ [zone]
+    | domain `isSubDomainOf` zone = takeWhile (/= zone) (reverse (superDomains domain) ++ [fromString "."]) ++ [zone]
     | otherwise = []

--- a/dnsext-iterative/DNS/Iterative/Query/ResolveJust.hs
+++ b/dnsext-iterative/DNS/Iterative/Query/ResolveJust.hs
@@ -81,7 +81,7 @@ resolveExactDC dc n typ
         throwDnsError DNS.ServerFailure
     | otherwise = do
         root <- refreshRoot
-        nss@Delegation{..} <- iterative_ dc root $ reverse $ DNS.superDomains n
+        nss@Delegation{..} <- iterative_ dc root $ DNS.superDomains n
         sas <- delegationIPs dc nss
         lift . logLn Log.DEMO $ unwords (["resolve-exact: query", show (n, typ), "servers:"] ++ [show sa | sa <- sas])
         let dnssecOK = delegationHasDS nss && not (null delegationDNSKEY)
@@ -259,7 +259,7 @@ _noLogging = const $ pure ()
 -- >>> runDNSQuery (testIterative "arpa.") env mempty $> ()  {- fill-action is called for `ServsChildZone` -}
 -- consume message found
 iterative :: Delegation -> Domain -> DNSQuery Delegation
-iterative sa n = iterative_ 0 sa $ reverse $ DNS.superDomains n
+iterative sa n = iterative_ 0 sa $ DNS.superDomains n
 
 iterative_ :: Int -> Delegation -> [Domain] -> DNSQuery Delegation
 iterative_ _ nss0 [] = return nss0

--- a/dnsext-iterative/DNS/Iterative/Query/Rev.hs
+++ b/dnsext-iterative/DNS/Iterative/Query/Rev.hs
@@ -101,7 +101,7 @@ v6EmbeddedResult =
 -- Right [4,3,2,1]
 parseV4RevDomain :: Domain -> Either String [Int]
 parseV4RevDomain dom = do
-    rparts <- maybe (throw "suffix does not match") Right $ L.stripPrefix sufV4 (reverse $ DNS.toWireLabels dom)
+    rparts <- maybe (throw "suffix does not match") Right $ L.stripPrefix sufV4 (DNS.revLabels dom)
     let plen = length rparts
     maybe (throw $ "invalid number of parts split by dot: " ++ show rparts) Right $ guard (1 <= plen && plen <= 4)
     mapM getByte rparts
@@ -122,7 +122,7 @@ parseV4RevDomain dom = do
 -- Right [2,0,0,1,0,13,11,8,0,15,0,0,0,0,0,0,0,0,1,2,3,4,15,15,15,14,5,6,7,8,9,10]
 parseV6RevDomain :: Domain -> Either String [Int]
 parseV6RevDomain dom = do
-    rparts <- maybe (throw "suffix does not match") Right $ L.stripPrefix sufV6 (reverse $ DNS.toWireLabels dom)
+    rparts <- maybe (throw "suffix does not match") Right $ L.stripPrefix sufV6 (DNS.revLabels dom)
     let plen = length rparts
     maybe (throw $ "invalid number of parts split by dot: " ++ show rparts) Right $ guard (1 <= plen && plen <= 32)
     mapM getHexDigit rparts

--- a/dnsext-types/DNS/Types.hs
+++ b/dnsext-types/DNS/Types.hs
@@ -167,6 +167,9 @@ module DNS.Types (
     -- ** Domain
     Domain,
     domainSize,
+    unconsDomain,
+    wireLabels,
+    revLabels,
     superDomains,
     isSubDomainOf,
 

--- a/dnsext-types/DNS/Wire/Builder.hs
+++ b/dnsext-types/DNS/Wire/Builder.hs
@@ -45,7 +45,7 @@ type Builder a = WriteBuffer -> IORef BState -> IO a
 
 -- | Builder state
 newtype BState = BState
-    { bstDomain :: Map [RawDomain] Int
+    { bstDomain :: Map WireLabels Int
     }
 
 initialBState :: BState
@@ -61,13 +61,13 @@ runBuilder len builder = unsafeDupablePerformIO $ do
 
 ----------------------------------------------------------------
 
-pushPointer :: [RawDomain] -> Int -> IORef BState -> IO ()
+pushPointer :: WireLabels -> Int -> IORef BState -> IO ()
 pushPointer dom pos ref = do
     BState m <- readIORef ref
     let m' = M.insert dom pos m
     writeIORef ref $ BState m'
 
-popPointer :: [RawDomain] -> IORef BState -> IO (Maybe Int)
+popPointer :: WireLabels -> IORef BState -> IO (Maybe Int)
 popPointer dom ref = M.lookup dom . bstDomain <$> readIORef ref
 
 ----------------------------------------------------------------

--- a/dnsext-types/DNS/Wire/Parser.hs
+++ b/dnsext-types/DNS/Wire/Parser.hs
@@ -54,7 +54,7 @@ type Parser a = ReadBuffer -> IORef PState -> IO a
 
 -- | Parser state
 data PState = PState
-    { pstDomain :: IntMap WireLabels
+    { pstDomain :: IntMap Labels
     , pstAtTime :: EpochTime
     }
     deriving (Eq, Show)
@@ -64,12 +64,12 @@ initialState t = PState IM.empty t
 
 ----------------------------------------------------------------
 
-pushDomain :: IM.Key -> WireLabels -> IORef PState -> IO ()
+pushDomain :: IM.Key -> Labels -> IORef PState -> IO ()
 pushDomain n d ref = do
     PState dom t <- readIORef ref
     writeIORef ref $ PState (IM.insert n d dom) t
 
-popDomain :: IM.Key -> IORef PState -> IO (Maybe WireLabels)
+popDomain :: IM.Key -> IORef PState -> IO (Maybe Labels)
 popDomain n ref = IM.lookup n . pstDomain <$> readIORef ref
 
 getAtTime :: IORef PState -> IO EpochTime

--- a/dnsext-types/DNS/Wire/Parser.hs
+++ b/dnsext-types/DNS/Wire/Parser.hs
@@ -54,7 +54,7 @@ type Parser a = ReadBuffer -> IORef PState -> IO a
 
 -- | Parser state
 data PState = PState
-    { pstDomain :: IntMap [RawDomain]
+    { pstDomain :: IntMap WireLabels
     , pstAtTime :: EpochTime
     }
     deriving (Eq, Show)
@@ -64,12 +64,12 @@ initialState t = PState IM.empty t
 
 ----------------------------------------------------------------
 
-pushDomain :: IM.Key -> [RawDomain] -> IORef PState -> IO ()
+pushDomain :: IM.Key -> WireLabels -> IORef PState -> IO ()
 pushDomain n d ref = do
     PState dom t <- readIORef ref
     writeIORef ref $ PState (IM.insert n d dom) t
 
-popDomain :: IM.Key -> IORef PState -> IO (Maybe [RawDomain])
+popDomain :: IM.Key -> IORef PState -> IO (Maybe WireLabels)
 popDomain n ref = IM.lookup n . pstDomain <$> readIORef ref
 
 getAtTime :: IORef PState -> IO EpochTime

--- a/dnsext-types/DNS/Wire/Types.hs
+++ b/dnsext-types/DNS/Wire/Types.hs
@@ -1,7 +1,10 @@
 module DNS.Wire.Types where
 
 import Data.ByteString.Short
+import Data.Vector (Vector)
 
-type RawDomain = ShortByteString
+type Label = ShortByteString
+
+type WireLabels = Vector Label
 
 type Position = Int

--- a/dnsext-types/DNS/Wire/Types.hs
+++ b/dnsext-types/DNS/Wire/Types.hs
@@ -4,7 +4,7 @@ import Data.ByteString.Short
 import Data.Vector (Vector)
 
 type Label = ShortByteString
-
+type Labels = [Label]
 type WireLabels = Vector Label
 
 type Position = Int

--- a/dnsext-types/dnsext-types.cabal
+++ b/dnsext-types/dnsext-types.cabal
@@ -61,6 +61,7 @@ library
         mtl,
         network-byte-order,
         unix-time,
+        vector,
         word8
 
     if impl(ghc >=8)


### PR DESCRIPTION
- Memory usage: much better
- CPU usage: vecotor's `>>=` consumes a lot

I like this because of its simplicity.