### PR TITLE
Fix typo in recursiveQeury

### DIFF
--- a/dnsext-bowline/dug/Recursive.hs
+++ b/dnsext-bowline/dug/Recursive.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TupleSections #-}
 
-module Recursive (recursiveQeury) where
+module Recursive (recursiveQuery) where
 
 import Control.Concurrent
 import Control.Concurrent.Async
@@ -43,7 +43,7 @@ import Text.Read (readMaybe)
 
 import Types
 
-recursiveQeury
+recursiveQuery
     :: [HostName]
     -> PortNumber
     -> (DNS.DNSMessage -> IO ())
@@ -51,7 +51,7 @@ recursiveQeury
     -> [(Question, QueryControls)]
     -> Options
     -> IO ()
-recursiveQeury mserver port putLn putLines qcs Options{..} = do
+recursiveQuery mserver port putLn putLines qcs Options{..} = do
     mbs <- case optResumptionFile of
         Nothing -> return Nothing
         Just file -> do

--- a/dnsext-bowline/dug/dug.hs
+++ b/dnsext-bowline/dug/dug.hs
@@ -41,7 +41,7 @@ import qualified DNS.Log as Log
 import Iterative (iterativeQuery)
 import JSON (showJSON)
 import Output (OutputFlag (..), pprResult)
-import Recursive (recursiveQeury)
+import Recursive (recursiveQuery)
 import Types
 
 ----------------------------------------------------------------
@@ -143,7 +143,7 @@ main = do
             iterativeQuery optDisableV6NS putLn putLines target
         else do
             let mserver = map (drop 1) at
-            recursiveQeury mserver port putLn putLines qs opts
+            recursiveQuery mserver port putLn putLines qs opts
     ------------------------
     putTime t0 putLines
     killThread tid


### PR DESCRIPTION
Renaming `recusiveQeury` to `recursiveQuery`