### PR TITLE
fixing dug

### DIFF
--- a/dnsext-do53/DNS/Do53/Internal.hs
+++ b/dnsext-do53/DNS/Do53/Internal.hs
@@ -65,6 +65,7 @@ module DNS.Do53.Internal (
     checkRespM,
     withLookupConfAndResolver,
     lazyTag,
+    raceAny,
 )
 where
 

--- a/dnsext-do53/DNS/Do53/Resolve.hs
+++ b/dnsext-do53/DNS/Do53/Resolve.hs
@@ -7,7 +7,7 @@ module DNS.Do53.Resolve (
 )
 where
 
-import Control.Concurrent.Async (Async, waitCatchSTM)
+import Control.Concurrent.Async (Async, waitCatchSTM, withAsync)
 import Control.Concurrent.STM
 import Control.Exception as E
 import Control.Monad (when)
@@ -67,7 +67,7 @@ resolveConcurrent
     :: NonEmpty ResolveInfo -> OneshotResolver -> Resolver
 resolveConcurrent ris@(ResolveInfo{rinfoActions = riAct} :| _) resolver q@Question{..} qctl = do
     caller <- TStat.getThreadLabel
-    ex <- E.try $ raceAny [(caller ++ ": do53-res: " ++ show (rinfoIP ri), resolver' ri) | ri <- NE.toList ris]
+    ex <- E.try $ raceAnyL [(caller ++ ": do53-res: " ++ show (rinfoIP ri), resolver' ri) | ri <- NE.toList ris]
     case ex of
         Right r@Result{..} -> do
             let ~tag =
@@ -105,18 +105,25 @@ resolveConcurrent ris@(ResolveInfo{rinfoActions = riAct} :| _) resolver q@Questi
 -- >>> tsleep n = threadDelay $ n * 100 * 1000
 -- >>> right n x = tsleep n $> x
 -- >>> left = fail
--- >>> raceAny [("a1", right 1 "good1"), ("a1", right 20 "good2"), ("a3", right 20 "good3")]
+-- >>> raceAny [right 1 "good1", right 20 "good2", right 20 "good3"]
 -- "good1"
--- >>> raceAny [("a1", right 1 "good1"), ("a1", right 20 "good2"), ("a3", left "bad")]
+-- >>> raceAny [right 1 "good1", right 20 "good2", left "bad"]
 -- "good1"
--- >>> raceAny [("a1", right 1 "good1"), ("a2", left "bad"), ("a3", right 20 "good3")]
+-- >>> raceAny [right 1 "good1", left "bad", right 20 "good3"]
 -- "good1"
--- >>> raceAny [("a1", left "bad"), ("a2", right 2 "good2"), ("a3", right 20 "good3")]
+-- >>> raceAny [left "bad", right 2 "good2", right 20 "good3"]
 -- "good2"
--- >>> raceAny [("a1", left "bad1"), ("a2", left "bad2"), ("a3", left "bad3")]
+-- >>> raceAny [left "bad1", left "bad2", left "bad3"]
 -- *** Exception: user error (bad3)
-raceAny :: [(String, IO a)] -> IO a
-raceAny ios = TStat.withAsyncs ios waitAnyRightCancel
+raceAny :: [IO a] -> IO a
+raceAny ios = withAsyncs ios waitAnyRightCancel
+  where
+    withAsyncs ps h = foldr op (\f -> h (f [])) ps id
+      where
+        op io action = \s -> withAsync io $ \a -> action (s . (a :))
+
+raceAnyL :: [(String, IO a)] -> IO a
+raceAnyL ios = TStat.withAsyncs ios waitAnyRightCancel
 
 waitAnyRightCancel :: [Async a] -> IO a
 waitAnyRightCancel asyncs = atomically (waitAnyRightSTM asyncs)

--- a/dnsext-do53/DNS/Do53/Types.hs
+++ b/dnsext-do53/DNS/Do53/Types.hs
@@ -238,9 +238,11 @@ data Reply = Reply
     deriving (Eq, Show)
 
 -- | The resolver type to send a question and receive a result.
+--   Exceptions are not thrown.
 type Resolver = Question -> QueryControls -> IO (Either DNSError Result)
 
 -- | Concurrent resolver which can be shared by multiple threads.
+--   'DNSError' is thrown.
 type PipelineResolver = (Resolver -> IO ()) -> IO ()
 
 -- | Resolver whose connection is persistent.

--- a/dnsext-dox/DNS/DoX/HTTP2.hs
+++ b/dnsext-dox/DNS/DoX/HTTP2.hs
@@ -26,7 +26,7 @@ import qualified Data.ByteString.Char8 as C8
 import Data.ByteString.Short (fromShort)
 import qualified Data.ByteString.Short as Short
 import Network.HTTP.Types
-import Network.HTTP2.Client (Client, SendRequest, getResponseBodyChunk, requestBuilder)
+import Network.HTTP2.Client (Client, SendRequest, getResponseBodyChunk, requestBuilder, responseStatus)
 import qualified Network.HTTP2.TLS.Client as H2
 import System.Timeout (timeout)
 import qualified UnliftIO.Exception as E
@@ -83,6 +83,7 @@ resolv
     -> Resolver
 resolv proto ident ri@ResolveInfo{..} sendRequest q qctl =
     sendRequest req $ \rsp -> do
+        when (responseStatus rsp /= Just ok200) $ E.throwIO OperationRefused
         let recvHTTP = recvManyN $ getResponseBodyChunk rsp
         (rx, bss) <- recvHTTP $ unVCLimit rinfoVCLimit
         now <- getTime


### PR DESCRIPTION
I'm now writing an article about `dug`.
During this work, I found two bugs of `dug`.

```
% dug @1.1.1.1 -d auto www.iij.ad.jp
;; 1.0.0.1#443/H2, Tx:42bytes, Rx:58bytes
...
www.iij.ad.jp.	46(secs)	IN	A	202.232.2.180
...
dug: DecodeError "incomplete input: BufferOverrun"
```

We got an answer but an error is also displayed.
This is because `concurrently` is used instead of `raceAny` (good timing!)

2606:4700:4700::1111 of h2 returns 403.
So, we need to check 200 and returns `OperationRefused` instead of `BufferOverrun`.