### PR TITLE
use tini for PID1 problem

### DIFF
--- a/build-docker/Dockerfile.ghcup
+++ b/build-docker/Dockerfile.ghcup
@@ -23,7 +23,7 @@ apt-get update
 DEBIAN_FRONTEND=noninteractive \
   apt-get install -y --no-install-recommends \
   build-essential binutils ca-certificates curl git openssl \
-  libgmp-dev libz-dev
+  libgmp-dev libz-dev tini
 
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | \
      BOOTSTRAP_HASKELL_NONINTERACTIVE=1                  \
@@ -98,6 +98,7 @@ EOF
 FROM debian:${DEBIAN_TAG}
 
 COPY --from=builder /opt/bowline /opt/bowline
+COPY --from=builder /usr/bin/tini /usr/bin/tini
 COPY scripts /
 
 WORKDIR /opt/bowline/
@@ -134,4 +135,4 @@ EXPOSE 10023/tcp
 
 EXPOSE 8080/tcp
 
-CMD ["/bowline.sh"]
+ENTRYPOINT ["/usr/bin/tini", "/bowline.sh"]

--- a/build-docker/Dockerfile.ghcup
+++ b/build-docker/Dockerfile.ghcup
@@ -135,4 +135,4 @@ EXPOSE 10023/tcp
 
 EXPOSE 8080/tcp
 
-ENTRYPOINT ["/usr/bin/tini", "/bowline.sh"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/bowline.sh"]

--- a/build-docker/Dockerfile.haskell
+++ b/build-docker/Dockerfile.haskell
@@ -20,7 +20,7 @@ set -e -x
 apt-get update
 DEBIAN_FRONTEND=noninteractive \
   apt-get install -y --no-install-recommends \
-  build-essential binutils ca-certificates curl git openssl
+  build-essential binutils ca-certificates curl git openssl tini
 EOF
 
 WORKDIR /tmp/src
@@ -80,6 +80,7 @@ EOF
 FROM debian:${DEBIAN_TAG}
 
 COPY --from=builder /opt/bowline /opt/bowline
+COPY --from=builder /usr/bin/tini /usr/bin/tini
 COPY scripts /
 
 WORKDIR /opt/bowline/
@@ -116,4 +117,4 @@ EXPOSE 10023/tcp
 
 EXPOSE 8080/tcp
 
-CMD ["/bowline.sh"]
+ENTRYPOINT ["/usr/bin/tini", "/bowline.sh"]

--- a/build-docker/Dockerfile.haskell
+++ b/build-docker/Dockerfile.haskell
@@ -117,4 +117,4 @@ EXPOSE 10023/tcp
 
 EXPOSE 8080/tcp
 
-ENTRYPOINT ["/usr/bin/tini", "/bowline.sh"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/bowline.sh"]

--- a/build-docker/scripts/bowline.sh
+++ b/build-docker/scripts/bowline.sh
@@ -1,3 +1,16 @@
 #! /bin/sh
 
-/opt/bowline/bin/bowline /opt/bowline/etc/bowline.conf "$@"
+case "$1" in
+	sh|bash)
+		exe="$1"
+		shift
+		exec /bin/$exe "$@"
+		;;
+	dug)
+		shift
+		exec /opt/bowline/bin/dug "$@"
+		;;
+	*)
+		exec /opt/bowline/bin/bowline /opt/bowline/etc/bowline.conf "$@"
+		;;
+esac


### PR DESCRIPTION
/bin/sh as init(PID 1) program does not handle SIGTERM.

So, docker stop cannot stop container immediately.
(wait 10 sec(default) and receive SIGKILL)

Using tini as init resolve this.
