### PR TITLE
CD (Check-Disabled) flag support

### DIFF
--- a/dnsext-do53/DNS/Do53/Lookup.hs
+++ b/dnsext-do53/DNS/Do53/Lookup.hs
@@ -146,7 +146,7 @@ cachePositive
     :: CacheConf -> RRCache -> Question -> EpochTime -> [ResourceRecord] -> IO ()
 cachePositive cconf c k now rss
     | ttl == 0 = return () -- does not cache anything
-    | otherwise = notVerified rds (return ()) $ \v -> insertPositive cconf c k now v ttl
+    | otherwise = noSig rds (return ()) $ \v -> insertPositive cconf c k now v ttl
   where
     rds = map rdata rss
     ttl = minimum $ map rrttl rss -- rss is non-empty

--- a/dnsext-iterative/DNS/Iterative/Query/API.hs
+++ b/dnsext-iterative/DNS/Iterative/Query/API.hs
@@ -112,10 +112,10 @@ ctrlFromRequestHeader reqF reqEH = DNS.doFlag doOp <> DNS.cdFlag cdOp <> DNS.adF
         | dnssecOK = FlagSet
         | otherwise = FlagClear
     cdOp
-        | dnssecOK, DNS.chkDisable reqF = FlagSet {- only check when DNSSEC OK -}
+        | DNS.chkDisable reqF = FlagSet
         | otherwise = FlagClear
     adOp
-        | dnssecOK, DNS.authenData reqF = FlagSet {- only check when DNSSEC OK -}
+        | DNS.authenData reqF = FlagSet
         | otherwise = FlagClear
 
     dnssecOK = case reqEH of

--- a/dnsext-iterative/DNS/Iterative/Query/Cache.hs
+++ b/dnsext-iterative/DNS/Iterative/Query/Cache.hs
@@ -229,7 +229,7 @@ cacheNoRRSIG rrs0 rank = do
         insertRRSet <- asks insert_
         hrrs $ \dom typ cls ttl rds -> do
             plogLn Log.DEBUG $ unwords ["RRset:", show (((dom, typ, cls), ttl), rank), ' ' : show rds]
-            liftIO $ Cache.notVerified rds (pure ()) $ \crs -> insertRRSet (DNS.Question dom typ cls) ttl crs rank
+            liftIO $ Cache.noSig rds (pure ()) $ \crs -> insertRRSet (DNS.Question dom typ cls) ttl crs rank
     (_, sortedRRs) = unzip $ SEC.sortRDataCanonical rrs0
 
 cacheSection :: (MonadIO m, MonadReader Env m) => [ResourceRecord] -> Ranking -> m ()

--- a/dnsext-iterative/DNS/Iterative/Query/Delegation.hs
+++ b/dnsext-iterative/DNS/Iterative/Query/Delegation.hs
@@ -97,13 +97,16 @@ noV4DEntry (DEstubA6  (_:|_))     = True
 -- Caching while retrieving delegation information from the authoritative server's reply
 delegationWithCache :: Domain -> [RD_DNSKEY] -> Domain -> DNSMessage -> DNSQuery MayDelegation
 delegationWithCache zone dnskeys dom msg = do
+    reqCD <- asksQC requestCD_
     {- There is delegation information only when there is a selectable NS -}
-    maybe (notFound $> noDelegation) (found >>> (<&> hasDelegation)) $ findDelegation nsps adds
+    maybe (notFound $> noDelegation) (found reqCD >>> (<&> hasDelegation)) $ findDelegation nsps adds
   where
     rankedDS = Cache.rkAuthority
-    found k = Verify.cases NoCheckDisabled zone dnskeys (getRanked rankedDS) msg dom DS fromDS (nullDS k) ncDS (withDS k)
+    found reqCD k = Verify.cases NoCheckDisabled zone dnskeys (getRanked rankedDS) msg dom DS fromDS (nullDS reqCD k) ncDS (withDS k)
     fromDS = DNS.fromRData . rdata
-    nullDS k = do
+    nullDS CheckDisabled   k =
+        vrfyLog (Just Yellow) "delegation - no DS, check disabled" $> k []
+    nullDS NoCheckDisabled k = do
         unsignedDelegationOrNoData $> ()
         vrfyLog (Just Yellow) "delegation - no DS, so no verification chain"
         cacheNoData dom DS (getRank rankedDS msg)

--- a/dnsext-iterative/DNS/Iterative/Query/Delegation.hs
+++ b/dnsext-iterative/DNS/Iterative/Query/Delegation.hs
@@ -98,11 +98,10 @@ noV4DEntry (DEstubA6  (_:|_))     = True
 delegationWithCache :: Domain -> [RD_DNSKEY] -> Domain -> DNSMessage -> DNSQuery MayDelegation
 delegationWithCache zone dnskeys dom msg = do
     {- There is delegation information only when there is a selectable NS -}
-    getSec <- asks currentSeconds_
-    maybe (notFound $> noDelegation) (found getSec >>> (<&> hasDelegation)) $ findDelegation nsps adds
+    maybe (notFound $> noDelegation) (found >>> (<&> hasDelegation)) $ findDelegation nsps adds
   where
     rankedDS = Cache.rkAuthority
-    found getSec k = Verify.cases getSec zone dnskeys (getRanked rankedDS) msg dom DS fromDS (nullDS k) ncDS (withDS k)
+    found k = Verify.cases NoCheckDisabled zone dnskeys (getRanked rankedDS) msg dom DS fromDS (nullDS k) ncDS (withDS k)
     fromDS = DNS.fromRData . rdata
     nullDS k = do
         unsignedDelegationOrNoData $> ()

--- a/dnsext-iterative/DNS/Iterative/Query/Helpers.hs
+++ b/dnsext-iterative/DNS/Iterative/Query/Helpers.hs
@@ -54,10 +54,10 @@ rrsigList zone dom typ rrs = rrListWith RRSIG getSIGRD dom pair rrs
     pair rd rr = (rd, rrttl rr)
 
 rrsetGoodSigs :: RRset -> [RD_RRSIG]
-rrsetGoodSigs = mayVerifiedRRS [] (const []) id . rrsMayVerified
+rrsetGoodSigs = mayVerifiedRRS [] [] (const []) id . rrsMayVerified
 
 rrsetValid :: RRset -> Bool
-rrsetValid = mayVerifiedRRS False (const False) (const True) . rrsMayVerified
+rrsetValid = mayVerifiedRRS False False (const False) (const True) . rrsMayVerified
 
 sigrdTypeWith :: TYPE -> RD_RRSIG -> Maybe RD_RRSIG
 sigrdTypeWith sigType sigrd = guard (rrsig_type sigrd == sigType) $> sigrd

--- a/dnsext-iterative/DNS/Iterative/Query/LocalZone.hs
+++ b/dnsext-iterative/DNS/Iterative/Query/LocalZone.hs
@@ -20,7 +20,7 @@ import DNS.Iterative.Query.ZoneMap
 -- >>> :seti -XStandaloneDeriving
 -- >>> deriving instance Eq RRset
 -- >>> :seti -XOverloadedStrings
--- >>> rrset dom typ rds = RRset dom typ IN 3600 rds NotVerifiedRRS
+-- >>> rrset dom typ rds = RRset dom typ IN 3600 rds notValidNoSig
 -- >>> kvp dom ps = (dom, [rrset dom typ rds | (typ, rds) <- ps ])
 -- >>> kvp1 dom typ rds = kvp dom [(typ, rds)]
 
@@ -32,7 +32,7 @@ nameMap lzones =
     rrKey = (,,) <$> rrname <*> rrtype <*> rrclass
     withName []            = error "newEnv.withName: group must not be null!"
     withName rrss@(rrs:_)  = (rrsName rrs, rrss)
-    getRRset rrs = canonicalRRset rrs (const Nothing) (\n t c ttl rds -> Just $ RRset n t c ttl rds NotVerifiedRRS)
+    getRRset rrs = canonicalRRset rrs (const Nothing) (\n t c ttl rds -> Just $ RRset n t c ttl rds notValidNoSig)
     zoneRRsets (_d, _zt, rrs) = mapMaybe getRRset $ groupBy ((==) `on` rrKey) $ sortOn rrKey rrs
     byName = map withName . groupBy ((==) `on` rrsName)
 {- FOURMOLU_ENABLE -}

--- a/dnsext-iterative/DNS/Iterative/Query/Resolve.hs
+++ b/dnsext-iterative/DNS/Iterative/Query/Resolve.hs
@@ -182,8 +182,8 @@ resolveTYPE bn typ = do
             let cninfo = (,) <$> (fst <$> uncons cnames) <*> pure cnameRRset
             when ansHasTYPE $ throwDnsError DNS.UnexpectedRDATA {- CNAME と目的の TYPE が同時に存在した場合はエラー -}
             cacheCNAME $> maybe (Right (msg, [], [])) Left cninfo
-    getSec <- asks currentSeconds_
-    Verify.cases getSec delegationZone delegationDNSKEY rankedAnswer msg bn CNAME cnDomain nullCNAME ncCNAME mkResult
+    reqCD <- asksQC requestCD_
+    Verify.cases reqCD delegationZone delegationDNSKEY rankedAnswer msg bn CNAME cnDomain nullCNAME ncCNAME mkResult
 
 maxCNameChain :: Int
 maxCNameChain = 16

--- a/dnsext-iterative/DNS/Iterative/Query/Rev.hs
+++ b/dnsext-iterative/DNS/Iterative/Query/Rev.hs
@@ -46,7 +46,7 @@ runEmbedResult dom emb = (DNS.NameErr, [], [soa emb])
             , rrsClass = IN
             , rrsTTL = ncttl
             , rrsRDatas = [DNS.rd_soa mname mail ser refresh retry expire ncttl]
-            , rrsMayVerified = NotVerifiedRRS
+            , rrsMayVerified = notValidNoSig
             }
 
 -- result for special IP-address block from reverse lookup domain

--- a/dnsext-iterative/DNS/Iterative/Query/Types.hs
+++ b/dnsext-iterative/DNS/Iterative/Query/Types.hs
@@ -26,6 +26,10 @@ module DNS.Iterative.Query.Types (
     QueryError (..),
     DNSQuery,
     MonadReaderQC (..),
+    CasesNotValid (..),
+    notValidNoSig,
+    notValidCheckDisabled,
+    notValidInvalid,
     MayVerifiedRRS (..),
     mayVerifiedRRS,
     DFreshState (..),
@@ -261,19 +265,34 @@ data DEntry
 
 {- FOURMOLU_DISABLE -}
 data MayVerifiedRRS
-    = NotVerifiedRRS       {- not judged valid or invalid -}
-    | InvalidRRS String    {- RRSIG found, but no RRSIG is passed -}
-    | ValidRRS [RD_RRSIG]  {- any RRSIG is passed. [RD_RRSIG] should be not null -}
+    = NotValidRRS CasesNotValid  {- not verified or invalid -}
+    | ValidRRS [RD_RRSIG]        {- any RRSIG is passed. [RD_RRSIG] should be not null -}
     deriving Eq
 
-instance Show MayVerifiedRRS where
-  show = mayVerifiedRRS "NotVerifiedRRS" ("InvalidRRS " ++) (("ValidRRS " ++) . show)
+data CasesNotValid
+    = NV_NoSig                   {- request RRSIG, but not returned -}
+    | NV_CheckDisabled           {- only for check-disabled state, so unknown whether verifiable or not. may verify again -}
+    | NV_Invalid String          {- RRSIG exists, but no good RRSIG is found -}
+    deriving (Eq, Show)
 
-mayVerifiedRRS :: a -> (String -> a) -> ([RD_RRSIG] -> a) -> MayVerifiedRRS -> a
-mayVerifiedRRS notVerified invalid valid m = case m of
-    NotVerifiedRRS  ->  notVerified
-    InvalidRRS es   ->  invalid es
-    ValidRRS sigs   ->  valid sigs
+notValidNoSig :: MayVerifiedRRS
+notValidNoSig = NotValidRRS NV_NoSig
+
+notValidCheckDisabled :: MayVerifiedRRS
+notValidCheckDisabled = NotValidRRS NV_CheckDisabled
+
+notValidInvalid :: String -> MayVerifiedRRS
+notValidInvalid = NotValidRRS . NV_Invalid
+
+instance Show MayVerifiedRRS where
+  show = mayVerifiedRRS "NotValidRRS NoSig" "NotValidRRS CheckDisabled" ("NotValidRRS_Invalid " ++) (("ValidRRS " ++) . show)
+
+mayVerifiedRRS :: a -> a -> (String -> a) -> ([RD_RRSIG] -> a) -> MayVerifiedRRS -> a
+mayVerifiedRRS noSig checkDisabled invalid valid m = case m of
+    NotValidRRS  NV_NoSig           ->  noSig
+    NotValidRRS  NV_CheckDisabled   ->  checkDisabled
+    NotValidRRS (NV_Invalid es)     ->  invalid es
+    ValidRRS sigs                   ->  valid sigs
 {- FOURMOLU_ENABLE -}
 
 data RRset = RRset

--- a/dnsext-iterative/DNS/Iterative/Query/Types.hs
+++ b/dnsext-iterative/DNS/Iterative/Query/Types.hs
@@ -163,7 +163,7 @@ data QueryError
 type ContextT m = ReaderT Env (ReaderT QueryContext m)
 type DNSQuery = ExceptT QueryError (ContextT IO)
 
-class MonadReaderQC m where
+class Monad m => MonadReaderQC m where
     asksQC :: (QueryContext -> a) -> m a
 
 instance Monad m => MonadReaderQC (ContextT m) where

--- a/dnsext-iterative/DNS/Iterative/Query/Verify.hs
+++ b/dnsext-iterative/DNS/Iterative/Query/Verify.hs
@@ -89,7 +89,7 @@ cases' getSec zone dnskeys srrs rank rrn rrty h nullK ncK0 rightK0
     verifiedK rrset@(RRset dom typ cls minTTL rds sigrds) = rightK0 fromRDs rrset (logInv *> cache)
       where
         cache = cacheRRset rank dom typ cls minTTL rds sigrds
-        logInv = mayVerifiedRRS (pure ()) (logInvalids . lines) (const $ pure ()) $ rrsMayVerified rrset
+        logInv = mayVerifiedRRS (pure ()) (pure ()) (logInvalids . lines) (const $ pure ()) $ rrsMayVerified rrset
         logInvalids  []    = clogLn Log.DEMO (Just Cyan)  "cases: InvalidRRS"
         logInvalids (e:es) = clogLn Log.DEMO (Just Cyan) ("cases: InvalidRRS: " ++ e) *> logLines Log.DEMO es
     rightK rrset sortedRRs = do
@@ -107,8 +107,8 @@ withVerifiedRRset
 withVerifiedRRset now dnskeys0 RRset{..} sortedRDatas sigs0 vk =
     vk $ RRset rrsName rrsType rrsClass minTTL rrsRDatas mayVerified
   where
-    noverify = (rrsTTL, NotVerifiedRRS)
-    invalid err = (rrsTTL, InvalidRRS err)
+    noverify = (rrsTTL, notValidNoSig)
+    invalid err = (rrsTTL, notValidInvalid err)
     valid goodSigs = (minimum $ rrsTTL : sigTTLs ++ map fromIntegral expireTTLs, ValidRRS sigrds)
       where
         (sigrds, sigTTLs) = unzip goodSigs
@@ -422,10 +422,10 @@ nsecxWithValid' withZippedSigs tag dnskeys getRanked msg nullK ncK invalidK vali
         (_ranges, rrsets) = unzip rps
         valid = all rrsetValid rrsets
 
-        notValidErrors = header : esInvalid ++ esNotVerified
+        notValidErrors = header : esInvalid ++ esNoSig
         header = tag ++ " verify errors: "
-        esInvalid = [ie | set <- rrsets, InvalidRRS ie <- [rrsMayVerified set]]
-        esNotVerified = "not-verified RRset list:" : ["  " ++ showRRset set | set <- rrsets, NotVerifiedRRS <- [rrsMayVerified set]]
+        esInvalid = [ie | set <- rrsets, NotValidRRS (NV_Invalid ie) <- [rrsMayVerified set]]
+        esNoSig = "no-sig RRset list:" : ["  " ++ showRRset set | set <- rrsets, NotValidRRS NV_NoSig <- [rrsMayVerified set]]
         showRRset RRset{..} = unwords [show rrsName, show rrsType, show rrsRDatas]
 
 {- FOURMOLU_DISABLE -}
@@ -463,7 +463,7 @@ canonicalRRset :: [ResourceRecord] -> (String -> a) -> (RRset -> [(Int, DNS.Buil
 canonicalRRset rrs leftK rightK =
     SEC.canonicalRRsetSorted' sortedRRs leftK mkRRset
   where
-    mkRRset dom typ cls ttl rds = rightK (RRset dom typ cls ttl rds NotVerifiedRRS) sortedRDatas
+    mkRRset dom typ cls ttl rds = rightK (RRset dom typ cls ttl rds notValidNoSig) sortedRDatas
     (sortedRDatas, sortedRRs) = unzip $ SEC.sortRDataCanonical rrs
 
 cacheRRset
@@ -477,9 +477,10 @@ cacheRRset
     -> MayVerifiedRRS
     -> m ()
 cacheRRset rank dom typ cls ttl rds mv =
-    mayVerifiedRRS notVerivied (const $ pure ()) valid mv
+    mayVerifiedRRS noSig checkDisalbed (const $ pure ()) valid mv
   where
-    notVerivied = Cache.notVerified rds (pure ()) doCache
+    noSig = Cache.notVerified rds (pure ()) doCache
+    checkDisalbed = pure ()
     valid sigs = Cache.valid rds sigs (pure ()) doCache
     doCache crs = do
         insertRRSet <- asks insert_

--- a/dnsext-iterative/DNS/Iterative/Query/Verify.hs
+++ b/dnsext-iterative/DNS/Iterative/Query/Verify.hs
@@ -479,7 +479,7 @@ cacheRRset
 cacheRRset rank dom typ cls ttl rds mv =
     mayVerifiedRRS noSig checkDisalbed (const $ pure ()) valid mv
   where
-    noSig = Cache.notVerified rds (pure ()) doCache
+    noSig = Cache.noSig rds (pure ()) doCache
     checkDisalbed = Cache.checkDisabled rds (pure ()) doCache
     valid sigs = Cache.valid rds sigs (pure ()) doCache
     doCache crs = do

--- a/dnsext-iterative/DNS/Iterative/Query/Verify.hs
+++ b/dnsext-iterative/DNS/Iterative/Query/Verify.hs
@@ -480,7 +480,7 @@ cacheRRset rank dom typ cls ttl rds mv =
     mayVerifiedRRS noSig checkDisalbed (const $ pure ()) valid mv
   where
     noSig = Cache.notVerified rds (pure ()) doCache
-    checkDisalbed = pure ()
+    checkDisalbed = Cache.checkDisabled rds (pure ()) doCache
     valid sigs = Cache.valid rds sigs (pure ()) doCache
     doCache crs = do
         insertRRSet <- asks insert_

--- a/dnsext-iterative/DNS/Iterative/Query/Verify.hs
+++ b/dnsext-iterative/DNS/Iterative/Query/Verify.hs
@@ -54,7 +54,7 @@ import DNS.Iterative.Query.Utils
 -- right case is after verified, with valid or invalid RRset.
 cases
     :: (MonadIO m, MonadReader Env m)
-    => IO EpochTime
+    => RequestCD
     -> Domain
     -> [RD_DNSKEY]
     -> (dm -> ([ResourceRecord], Ranking)) -> dm
@@ -63,8 +63,9 @@ cases
     -> m b -> (m () -> m b)
     -> ([a] -> RRset -> m () -> m b)
     -> m b
-cases getSec zone dnskeys getRanked msg rrn rrty h nullK ncK rightK =
-    withSection getRanked msg $ \srrs rank -> cases' getSec NoCheckDisabled zone dnskeys srrs rank rrn rrty h nullK ncK rightK
+cases reqCD zone dnskeys getRanked msg rrn rrty h nullK ncK rightK = do
+    getSec <- asks currentSeconds_
+    withSection getRanked msg $ \srrs rank -> cases' getSec reqCD zone dnskeys srrs rank rrn rrty h nullK ncK rightK
 {- FOURMOLU_ENABLE -}
 
 {- FOURMOLU_DISABLE -}

--- a/dnsext-utils/DNS/RRCache/Types.hs
+++ b/dnsext-utils/DNS/RRCache/Types.hs
@@ -63,9 +63,6 @@ module DNS.RRCache.Types (
     negWithSOA,
     negNoSOA,
 
-    mkNotVerified,
-    notVerified,
-
     -- * tests
     lookup,
     lookupEither,
@@ -158,14 +155,6 @@ mkNoSig d ds = Positive $ PosNoSig (d :| ds)
 
 noSig :: [RData] -> a -> (Hit -> a) -> a
 noSig rds nothing just = cons1 rds nothing ((just .) . mkNoSig)
-
-{-# DEPRECATED mkNotVerified "use mkNoSig" #-}
-mkNotVerified :: RData -> [RData] -> Hit
-mkNotVerified = mkNoSig
-
-{-# DEPRECATED notVerified "use noSig" #-}
-notVerified :: [RData] -> a -> (Hit -> a) -> a
-notVerified = noSig
 
 mkCheckDisabled :: RData -> [RData] -> Hit
 mkCheckDisabled d ds = Positive $ PosCheckDisabled (d :| ds)

--- a/dnsext-utils/test/CacheProp.hs
+++ b/dnsext-utils/test/CacheProp.hs
@@ -130,7 +130,7 @@ genCrsAssoc =
     ]
   where
     crset [] = error "genCrsAssoc: only not empty allowed"
-    crset (d : ds) = Cache.mkNotVerified d ds
+    crset (d : ds) = Cache.mkNoSig d ds
 
 toULString :: String -> Gen String
 toULString s = zipWith ulc <$> vectorOf (length s) arbitrary <*> pure s


### PR DESCRIPTION
`+cdflag` causes iterative searches without DNSSEC validation. `bowline` cache will now take the `+cdflag` into account.

```
 % dug -i -v 1 brokendnssec.net.
resolve-with-cname: query: "brokendnssec.net." A IN
resolve-with-cname: query:   DO: NoDnssecOK
resolve-with-cname: query:   CD: NoCheckDisabled
resolve-with-cname: query:   AD: NoAuthenticatedData
...
no delegation: "cloudflare.com." -> "cruz.ns.cloudflare.com."
resolve-exact: query ("cruz.ns.cloudflare.com.",AAAA) servers: (162.159.4.8,53) (162.159.6.6,53) (2400:cb00:2049:1::a29f:30b,53) (2400:cb00:2049:1::a29f:506,53)
    query "cruz.ns.cloudflare.com." AAAA to 162.159.4.8#53/UDP
    query "cruz.ns.cloudflare.com." AAAA to 162.159.6.6#53/UDP
    query "cruz.ns.cloudflare.com." AAAA to 2400:cb00:2049:1::a29f:30b#53/UDP
    query "cruz.ns.cloudflare.com." AAAA to 2400:cb00:2049:1::a29f:506#53/UDP
    query "cruz.ns.cloudflare.com." AAAA to 162.159.4.8#53/UDP: win
verification success - RRSIG of "cruz.ns.cloudflare.com." AAAA
fillDelegationDNSKEY: query ("brokendnssec.net.",DNSKEY) servers: (2606:4700:50::adf5:3a58,53)
    query "brokendnssec.net." DNSKEY to 2606:4700:50::adf5:3a58#53/UDP
fillDelegationDNSKEY: sepkeyDS: no DNSKEY matches with DS
fillsDNSSEC: "brokendnssec.net.": DS is 'chained'-state, and DNSKEY is null
"brokendnssec.net.": verification error. dangling DS chain. DS exists, and DNSKEY does not exists
;; HEADER SECTION:
;Standard query, ServFail, id: 0
;Flags: Recursion Desired, Recursion Available


;; QUESTION SECTION:
;brokendnssec.net.		IN	A

;; ANSWER SECTION:

;; AUTHORITY SECTION:

;; ADDITIONAL SECTION:

;; 253usec
```

```
 % dug -i -v 1 brokendnssec.net. +cdflag
resolve-with-cname: query: "brokendnssec.net." A IN
resolve-with-cname: query:   DO: NoDnssecOK
resolve-with-cname: query:   CD: CheckDisabled
resolve-with-cname: query:   AD: NoAuthenticatedData
...
no delegation: "cloudflare.com." -> "carl.ns.cloudflare.com."
resolve-exact: query ("carl.ns.cloudflare.com.",AAAA) servers: (2400:cb00:2049:1::a29f:21,53) (2400:cb00:2049:1::a29f:408,53) (2400:cb00:2049:1::a29f:606,53) (2400:cb00:2049:1::a29f:7e2,53)
    query "carl.ns.cloudflare.com." AAAA to 2400:cb00:2049:1::a29f:21#53/UDP
    query "carl.ns.cloudflare.com." AAAA to 2400:cb00:2049:1::a29f:408#53/UDP
    query "carl.ns.cloudflare.com." AAAA to 2400:cb00:2049:1::a29f:606#53/UDP
    query "carl.ns.cloudflare.com." AAAA to 2400:cb00:2049:1::a29f:7e2#53/UDP
    query "carl.ns.cloudflare.com." AAAA to 2400:cb00:2049:1::a29f:21#53/UDP: win
no verification - no DS, "carl.ns.cloudflare.com." AAAA
resolve-exact: query ("brokendnssec.net.",A) servers: (2606:4700:58::adf5:3b6a,53)
    query "brokendnssec.net." A to 2606:4700:58::adf5:3b6a#53/UDP
no verification - no DS, "brokendnssec.net." A
;; HEADER SECTION:
;Standard query, NoError, id: 0
;Flags: Recursion Desired, Recursion Available


;; QUESTION SECTION:
;brokendnssec.net.		IN	A

;; ANSWER SECTION:
brokendnssec.net.	300(5 mins)	IN	A	104.22.48.232
brokendnssec.net.	300(5 mins)	IN	A	104.22.49.232
brokendnssec.net.	300(5 mins)	IN	A	172.67.29.10

;; AUTHORITY SECTION:

;; ADDITIONAL SECTION:

;; 182usec

```

```
 % dug -i -v 1 iij.ad.jp.
resolve-with-cname: query: "iij.ad.jp." A IN
resolve-with-cname: query:   DO: NoDnssecOK
resolve-with-cname: query:   CD: NoCheckDisabled
resolve-with-cname: query:   AD: NoAuthenticatedData
...
delegation - verification success - RRSIG of DS: "jp." -> "iij.ad.jp."
zone: "iij.ad.jp.":
	"dns0.iij.ad.jp." 210.130.0.5@53, 2001:240::105@53
	"dns1.iij.ad.jp." 210.130.1.5@53, 2001:240::115@53
fillDelegationDNSKEY: query ("iij.ad.jp.",DNSKEY) servers: (2001:240::105,53) (2001:240::115,53)
    query "iij.ad.jp." DNSKEY to 2001:240::105#53/UDP
    query "iij.ad.jp." DNSKEY to 2001:240::115#53/UDP
    query "iij.ad.jp." DNSKEY to 2001:240::105#53/UDP: win
resolve-exact: query ("iij.ad.jp.",A) servers: (2001:240::105,53) (2001:240::115,53)
    query "iij.ad.jp." A to 2001:240::105#53/UDP
    query "iij.ad.jp." A to 2001:240::115#53/UDP
    query "iij.ad.jp." A to 2001:240::115#53/UDP: win
verification success - RRSIG of "iij.ad.jp." A
;; HEADER SECTION:
;Standard query, NoError, id: 0
;Flags: Recursion Desired, Recursion Available


;; QUESTION SECTION:
;iij.ad.jp.		IN	A

;; ANSWER SECTION:
iij.ad.jp.	300(5 mins)	IN	A	202.232.2.191

;; AUTHORITY SECTION:

;; ADDITIONAL SECTION:

;; 70usec
```

```
 % dug -i -v 1 iij.ad.jp. +cdflag
resolve-with-cname: query: "iij.ad.jp." A IN
resolve-with-cname: query:   DO: NoDnssecOK
resolve-with-cname: query:   CD: CheckDisabled
resolve-with-cname: query:   AD: NoAuthenticatedData
...
delegation - no DS, check disabled: "jp." -> "iij.ad.jp."
zone: "iij.ad.jp.":
	"dns0.iij.ad.jp." 210.130.0.5@53, 2001:240::105@53
	"dns1.iij.ad.jp." 210.130.1.5@53, 2001:240::115@53
resolve-exact: query ("iij.ad.jp.",A) servers: (210.130.1.5,53) (2001:240::105,53)
    query "iij.ad.jp." A to 210.130.1.5#53/UDP
    query "iij.ad.jp." A to 2001:240::105#53/UDP
    query "iij.ad.jp." A to 210.130.1.5#53/UDP: win
no verification - no DS, "iij.ad.jp." A
;; HEADER SECTION:
;Standard query, NoError, id: 0
;Flags: Recursion Desired, Recursion Available


;; QUESTION SECTION:
;iij.ad.jp.		IN	A

;; ANSWER SECTION:
iij.ad.jp.	300(5 mins)	IN	A	202.232.2.191

;; AUTHORITY SECTION:

;; ADDITIONAL SECTION:

;; 99usec
```
