### PR TITLE
Ensure that the VC sender-loop waits for a synchronization event to terminate.

### DIFF
--- a/dnsext-iterative/DNS/Iterative/Server/Bench.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/Bench.hs
@@ -54,7 +54,7 @@ benchServer bench_pipelines env _ = do
 
     let toSender = atomically . writeTQueue resQ
 
-        enqueueReq (bs, ()) = toCacher (Input bs myDummy (PeerInfoUDP clntDummy) UDP toSender)
+        enqueueReq (bs, ()) = toCacher (Input bs 0 myDummy (PeerInfoUDP clntDummy) UDP toSender)
         dequeueRes = (\(Output bs _) -> (bs, ())) <$> atomically (readTQueue resQ)
     return (cachers ++ workers, enqueueReq, dequeueRes)
   where

--- a/dnsext-iterative/DNS/Iterative/Server/Bench.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/Bench.hs
@@ -55,7 +55,7 @@ benchServer bench_pipelines env _ = do
     let toSender = atomically . writeTQueue resQ
 
         enqueueReq (bs, ()) = toCacher (Input bs 0 myDummy (PeerInfoUDP clntDummy) UDP toSender)
-        dequeueRes = (\(Output bs _) -> (bs, ())) <$> atomically (readTQueue resQ)
+        dequeueRes = (\(Output bs _ _) -> (bs, ())) <$> atomically (readTQueue resQ)
     return (cachers ++ workers, enqueueReq, dequeueRes)
   where
     getSockAddr host port = do

--- a/dnsext-iterative/DNS/Iterative/Server/HTTP2.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/HTTP2.hs
@@ -79,7 +79,7 @@ doHTTP name sbracket incQuery env toCacher ServerIO{..} = do
                     incQuery sioPeerSockAddr
                     toCacher inp
         sender = forever $ do
-            Output bs' (PeerInfoH2 _ strm) <- fromX
+            Output bs' _ (PeerInfoH2 _ strm) <- fromX
             let header = mkHeader bs'
                 response = H2.responseBuilder HT.ok200 header $ byteString bs'
             sioWriteResponse strm response

--- a/dnsext-iterative/DNS/Iterative/Server/HTTP2.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/HTTP2.hs
@@ -67,7 +67,7 @@ http2cServer VcServerConfig{..} env toCacher port host = do
 doHTTP
     :: String -> (IO () -> IO ()) -> (SockAddr -> IO ()) -> Env -> ToCacher -> ServerIO -> IO (IO ())
 doHTTP name sbracket incQuery env toCacher ServerIO{..} = do
-    (toSender, fromX) <- mkConnector
+    (toSender, fromX, _) <- mkConnector
     let receiver = forever $ do
             (_, strm, req) <- sioReadRequest
             let peerInfo = PeerInfoH2 sioPeerSockAddr strm

--- a/dnsext-iterative/DNS/Iterative/Server/HTTP2.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/HTTP2.hs
@@ -75,7 +75,7 @@ doHTTP name sbracket incQuery env toCacher ServerIO{..} = do
             case einp of
                 Left emsg -> logLn env Log.WARN $ "decode-error: " ++ emsg
                 Right bs -> do
-                    let inp = Input bs sioMySockAddr peerInfo DOH toSender
+                    let inp = Input bs 0 sioMySockAddr peerInfo DOH toSender
                     incQuery sioPeerSockAddr
                     toCacher inp
         sender = forever $ do

--- a/dnsext-iterative/DNS/Iterative/Server/HTTP3.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/HTTP3.hs
@@ -63,7 +63,7 @@ doHTTP env toCacher req aux sendResponse = do
             let inp = Input bs 0 mysa peerInfo DOH toSender
             incStatsDoH3 peersa (stats_ env)
             toCacher inp
-            Output bs' _ <- fromX
+            Output bs' _ _ <- fromX
             let header = mkHeader bs'
                 response = H2.responseBuilder HT.ok200 header $ byteString bs'
             sendResponse response []

--- a/dnsext-iterative/DNS/Iterative/Server/HTTP3.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/HTTP3.hs
@@ -55,7 +55,7 @@ doHTTP env toCacher req aux sendResponse = do
     let mysa = H2.auxMySockAddr aux
         peersa = H2.auxPeerSockAddr aux
         peerInfo = PeerInfoVC peersa
-    (toSender, fromX) <- mkConnector
+    (toSender, fromX, _) <- mkConnector
     einp <- getInput req
     case einp of
         Left emsg -> logLn env Log.WARN $ "decode-error: " ++ emsg

--- a/dnsext-iterative/DNS/Iterative/Server/HTTP3.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/HTTP3.hs
@@ -60,7 +60,7 @@ doHTTP env toCacher req aux sendResponse = do
     case einp of
         Left emsg -> logLn env Log.WARN $ "decode-error: " ++ emsg
         Right bs -> do
-            let inp = Input bs mysa peerInfo DOH toSender
+            let inp = Input bs 0 mysa peerInfo DOH toSender
             incStatsDoH3 peersa (stats_ env)
             toCacher inp
             Output bs' _ <- fromX

--- a/dnsext-iterative/DNS/Iterative/Server/Pipeline.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/Pipeline.hs
@@ -212,16 +212,15 @@ logLn env level = logLines_ env level Nothing . (: [])
 ----------------------------------------------------------------
 
 handledLoop :: Env -> String -> IO () -> IO ()
-handledLoop env tag body = forever $ handle onError body
-  where
-    onError (SomeException e) = logLn env Log.WARN (tag ++ ": " ++ show e)
+handledLoop env tag body = forever $ handle (warnOnError env tag) body
 
 breakableLoop :: Env -> String -> IO () -> IO ()
 breakableLoop env tag body = forever body `catch` onError
   where
-    onError (SomeException e) = do
-        logLn env Log.WARN (tag ++ ": " ++ show e)
-        throwIO e
+    onError se@(SomeException e) = warnOnError env tag se *> throwIO e
+
+warnOnError :: Env -> String -> SomeException -> IO ()
+warnOnError env tag (SomeException e) = logLn env Log.WARN (tag ++ ": exception: " ++ show e)
 
 ----------------------------------------------------------------
 

--- a/dnsext-iterative/DNS/Iterative/Server/Pipeline.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/Pipeline.hs
@@ -240,11 +240,8 @@ addVcPending pendings i = modifyTVar' pendings (Set.insert i)
 delVcPending :: VcPendings -> Int -> STM ()
 delVcPending pendings i = modifyTVar' pendings (Set.delete i)
 
-mkConnector :: IO (ToSender, FromX)
-mkConnector = (\(t, f, _) -> (t, f)) <$> mkConnector'
-
-mkConnector' :: IO (ToSender, FromX, VcRespAvail)
-mkConnector' = do
+mkConnector :: IO (ToSender, FromX, VcRespAvail)
+mkConnector = do
     qs <- newTQueueIO
     let toSender = atomically . writeTQueue qs
         fromX = atomically $ readTQueue qs

--- a/dnsext-iterative/DNS/Iterative/Server/Pipeline.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/Pipeline.hs
@@ -89,7 +89,7 @@ cacherLogic env fromReceiver toWorker = handledLoop env "cacher" $ do
                     mapM_ (incStats $ stats_ env) [CacheHit, QueriesAll]
                     let bs = DNS.encode replyMsg
                     record env inp replyMsg bs
-                    inputToSender $ Output bs inputPeerInfo
+                    inputToSender $ Output bs inputRequestNum inputPeerInfo
                 CResultDenied _replyErr -> logicDenied env inp
 
 ----------------------------------------------------------------
@@ -108,7 +108,7 @@ workerLogic env WorkerStatOP{..} fromCacher = handledLoop env "worker" $ do
             mapM_ (incStats $ stats_ env) [CacheMiss, QueriesAll]
             let bs = DNS.encode replyMsg
             record env inp replyMsg bs
-            inputToSender $ Output bs inputPeerInfo
+            inputToSender $ Output bs inputRequestNum inputPeerInfo
         Left _e -> logicDenied env inp
 
 ----------------------------------------------------------------
@@ -201,7 +201,7 @@ senderLogicVC env send fromX =
 
 senderLogic' :: Send -> FromX -> IO ()
 senderLogic' send fromX = do
-    Output bs peerInfo <- fromX
+    Output bs _ peerInfo <- fromX
     send bs peerInfo
 
 ----------------------------------------------------------------

--- a/dnsext-iterative/DNS/Iterative/Server/Pipeline.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/Pipeline.hs
@@ -188,7 +188,7 @@ receiverLogic' mysa recv toCacher toSender proto = do
     if bs == ""
         then return False
         else do
-            toCacher $ Input bs mysa peerInfo proto toSender
+            toCacher $ Input bs 0 mysa peerInfo proto toSender
             return True
 
 senderLogic :: Env -> Send -> FromX -> IO ()

--- a/dnsext-iterative/DNS/Iterative/Server/QUIC.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/QUIC.hs
@@ -42,7 +42,7 @@ quicServer VcServerConfig{..} env toCacher port host = do
         info <- QUIC.getConnectionInfo conn
         let mysa = QUIC.localSockAddr info
             peersa = QUIC.remoteSockAddr info
-        (toSender, fromX) <- mkConnector
+        (toSender, fromX, _) <- mkConnector
         th <- T.registerKillThread mgr $ return ()
         let recv = do
                 strm <- QUIC.acceptStream conn

--- a/dnsext-iterative/DNS/Iterative/Server/TCP.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/TCP.hs
@@ -37,7 +37,7 @@ tcpServer VcServerConfig{..} env toCacher port host = do
         mysa <- getSocketName sock
         peersa <- getPeerName sock
         let peerInfo = PeerInfoVC peersa
-        (toSender, fromX) <- mkConnector
+        (toSender, fromX, _) <- mkConnector
         th <- T.registerKillThread mgr $ return ()
         let recv = do
                 (siz, bss) <- DNS.recvVC maxSize $ DNS.recvTCP sock

--- a/dnsext-iterative/DNS/Iterative/Server/TLS.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/TLS.hs
@@ -9,6 +9,7 @@ import qualified Data.ByteString as BS
 
 -- dnsext-* packages
 import qualified DNS.Do53.Internal as DNS
+import qualified DNS.Log as Log
 import DNS.TAP.Schema (SocketProtocol (..))
 import qualified DNS.ThreadStats as TStat
 
@@ -40,14 +41,17 @@ tlsServer VcServerConfig{..} env toCacher port host = do
         let mysa = H2.mySockAddr backend
             peersa = H2.peerSockAddr backend
             peerInfo = PeerInfoVC peersa
+        logLn env Log.DEBUG $ "tls-srv: accept: " ++ show peersa
         recvN <- makeRecvN "" $ H2.recv backend
-        (toSender, fromX, _) <- mkConnector
+        (toSender, fromX, availX) <- mkConnector
+        (vcEOF, vcPendings) <- mkVcState
         let recv = do
                 (siz, bss) <- DNS.recvVC maxSize recvN
                 if siz == 0
                     then return ("", peerInfo)
                     else incStatsDoT peersa (stats_ env) $> (BS.concat bss, peerInfo)
             send bs _ = DNS.sendVC (H2.sendMany backend) bs
-            receiver = receiverLogicVC env mysa recv toCacher toSender DOT
-            sender = senderLogicVC env send fromX
+            receiver = receiverLoopVC env vcEOF vcPendings mysa recv toCacher toSender DOT
+            sender = senderLoopVC "tls-send" env vcEOF vcPendings availX send fromX
         TStat.concurrently_ "tls-send" sender "tls-recv" receiver
+        logLn env Log.DEBUG $ "tls-srv: close: " ++ show peersa

--- a/dnsext-iterative/DNS/Iterative/Server/TLS.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/TLS.hs
@@ -41,7 +41,7 @@ tlsServer VcServerConfig{..} env toCacher port host = do
             peersa = H2.peerSockAddr backend
             peerInfo = PeerInfoVC peersa
         recvN <- makeRecvN "" $ H2.recv backend
-        (toSender, fromX) <- mkConnector
+        (toSender, fromX, _) <- mkConnector
         let recv = do
                 (siz, bss) <- DNS.recvVC maxSize recvN
                 if siz == 0

--- a/dnsext-iterative/DNS/Iterative/Server/Types.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/Types.hs
@@ -10,6 +10,7 @@ module DNS.Iterative.Server.Types (
     FromCacher,
     ToSender,
     FromX,
+    ReqNum,
     Input (..),
     Output (..),
     PeerInfo (..),
@@ -48,8 +49,12 @@ peerSockAddr (PeerInfoQUIC sa _) = sa
 peerSockAddr (PeerInfoH2 sa _) = sa
 peerSockAddr (PeerInfoVC sa) = sa
 
+-- request identifier in one connection
+type ReqNum = Int
+
 data Input a = Input
     { inputQuery :: a
+    , inputRequestNum :: ReqNum
     , inputMysa :: SockAddr
     , inputPeerInfo :: PeerInfo
     , inputProto :: SocketProtocol

--- a/dnsext-iterative/DNS/Iterative/Server/Types.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/Types.hs
@@ -63,6 +63,7 @@ data Input a = Input
 
 data Output = Output
     { outputReplyBS :: ByteString
+    , outputRequestNum :: ReqNum
     , outputPeerInfo :: PeerInfo
     }
 


### PR DESCRIPTION
After TCP53 or DoT query, if you look at the state of the sender thread, you will see that it is `ThreadBlocked` and is still waiting.

```
monitor> tstats tcp
tcp-recv             : 305: ThreadFinished
tcp-send             : 304: ThreadBlocked BlockedOnSTM
tcp-srv              : 144: ThreadBlocked BlockedOnMVar
tcp-srv              : 151: ThreadBlocked BlockedOnMVar
```

```
monitor> tstats tls
tls-recv             : 464: ThreadFinished
tls-send             : 463: ThreadBlocked BlockedOnSTM
tls-srv              : 163: ThreadBlocked BlockedOnMVar
tls-srv              : 167: ThreadBlocked BlockedOnMVar
```

The end condition of the sender is determined by waiting for three states:
- EOF state
- requests being processed
- availability of retrieving the result (from queue).
