### PR TITLE
removing unliftio

### DIFF
--- a/dnsext-bowline/bowline/DNSTAP.hs
+++ b/dnsext-bowline/bowline/DNSTAP.hs
@@ -8,12 +8,12 @@ module DNSTAP (
 
 import Control.Concurrent
 import Control.Concurrent.STM
+import qualified Control.Exception as E
 import Control.Monad (when)
 import qualified DNS.TAP.FastStream as FSTRM
 import DNS.TAP.Schema
 import Data.IORef
 import Network.Socket
-import qualified UnliftIO.Exception as E
 
 import Config
 

--- a/dnsext-bowline/bowline/WebAPI.hs
+++ b/dnsext-bowline/bowline/WebAPI.hs
@@ -4,13 +4,13 @@
 module WebAPI (new) where
 
 import Control.Concurrent
-import Data.String
+import qualified Control.Exception as E
 import Data.ByteString ()
+import Data.String
 import qualified Network.HTTP.Types as HTTP
 import Network.Socket
 import Network.Wai
 import Network.Wai.Handler.Warp
-import qualified UnliftIO.Exception as E
 
 import DNS.Iterative.Server (withLocationIOE)
 

--- a/dnsext-bowline/bowline/bowline.hs
+++ b/dnsext-bowline/bowline/bowline.hs
@@ -29,6 +29,8 @@ import System.Timeout (timeout)
 import Text.Printf (printf)
 
 -- dnsext-* deps
+
+import Control.Exception (finally)
 import DNS.Iterative.Server as Server
 import qualified DNS.Log as Log
 import qualified DNS.RRCache as Cache
@@ -41,7 +43,6 @@ import DNS.Types.Internal (TYPE (..))
 import Network.Socket
 import Network.TLS (Credentials (..), credentialLoadX509)
 import qualified Network.TLS.SessionTicket as ST
-import UnliftIO.Exception (finally)
 
 -- this package
 import Config

--- a/dnsext-bowline/dnsext-bowline.cabal
+++ b/dnsext-bowline/dnsext-bowline.cabal
@@ -42,7 +42,6 @@ executable bowline
         tls >= 2.1,
         tls-session-manager,
         unix,
-        unliftio,
         wai,
         warp
 

--- a/dnsext-dox/DNS/DoX/HTTP2.hs
+++ b/dnsext-dox/DNS/DoX/HTTP2.hs
@@ -14,6 +14,7 @@ module DNS.DoX.HTTP2 (
 )
 where
 
+import qualified Control.Exception as E
 import DNS.Do53.Client
 import DNS.Do53.Internal
 import qualified DNS.Log as Log
@@ -29,7 +30,6 @@ import Network.HTTP.Types
 import Network.HTTP2.Client (Client, SendRequest, getResponseBodyChunk, requestBuilder, responseStatus)
 import qualified Network.HTTP2.TLS.Client as H2
 import System.Timeout (timeout)
-import qualified UnliftIO.Exception as E
 
 import DNS.DoX.Imports
 import DNS.DoX.TLS

--- a/dnsext-dox/DNS/DoX/HTTP3.hs
+++ b/dnsext-dox/DNS/DoX/HTTP3.hs
@@ -3,11 +3,11 @@
 
 module DNS.DoX.HTTP3 where
 
+import qualified Control.Exception as E
 import DNS.Do53.Client
 import DNS.Do53.Internal
 import Network.HTTP3.Client
 import qualified Network.QUIC.Client as QUIC
-import qualified UnliftIO.Exception as E
 
 import DNS.DoX.HTTP2
 import DNS.DoX.QUIC

--- a/dnsext-dox/dnsext-dox.cabal
+++ b/dnsext-dox/dnsext-dox.cabal
@@ -51,8 +51,7 @@ library
         recv >=0.1.0,
         serialise,
         time-manager,
-        tls >= 2.1,
-        unliftio
+        tls >= 2.1
 
     if impl(ghc >=8)
         default-extensions: Strict StrictData

--- a/dnsext-iterative/DNS/Iterative/Server/Pipeline.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/Pipeline.hs
@@ -31,6 +31,7 @@ module DNS.Iterative.Server.Pipeline (
 -- GHC packages
 import Control.Concurrent (threadWaitReadSTM)
 import Control.Concurrent.STM
+import Control.Exception (SomeException (..), handle, throwIO)
 import qualified Control.Exception as E
 import qualified Data.ByteString as BS
 import qualified Data.IntSet as Set
@@ -38,7 +39,6 @@ import GHC.Event (TimeoutKey, TimerManager, getSystemTimerManager, registerTimeo
 import System.Posix.Types (Fd (..))
 
 -- libs
-import UnliftIO.Exception (SomeException (..), handle, throwIO)
 
 -- dnsext packages
 import qualified DNS.Log as Log

--- a/dnsext-iterative/dnsext-iterative.cabal
+++ b/dnsext-iterative/dnsext-iterative.cabal
@@ -82,7 +82,6 @@ library
         stm,
         time-manager,
         tls >= 2.1,
-        unliftio,
         word8
 
     if impl(ghc >=8)
@@ -102,8 +101,7 @@ executable workers-benchmark
         dnsext-iterative,
         dnsext-types,
         dnsext-utils,
-        unix-time,
-        unliftio
+        unix-time
 
     if (os(windows) && impl(ghc >=9.0))
         ghc-options: -with-rtsopts=--io-manager=native

--- a/dnsext-utils/DNS/TAP/FastStream.hs
+++ b/dnsext-utils/DNS/TAP/FastStream.hs
@@ -24,14 +24,15 @@ module DNS.TAP.FastStream (
     bye,
 ) where
 
+import Control.Exception as E
 import Control.Monad
 import qualified Data.ByteString.Char8 as C8
+import Data.Typeable (Typeable)
 import Data.Word
 import Network.ByteOrder
 import Network.Socket
 import qualified Network.Socket.BufferPool as P
 import qualified Network.Socket.ByteString as NSB
-import UnliftIO.Exception as E
 
 ----------------------------------------------------------------
 

--- a/dnsext-utils/dnsext-utils.cabal
+++ b/dnsext-utils/dnsext-utils.cabal
@@ -53,7 +53,6 @@ library
         stm,
         transformers,
         unix-time,
-        unliftio,
         vector,
         word8
 
@@ -81,8 +80,7 @@ test-suite spec
         dnsext-types,
         dnsext-utils,
         hspec,
-        network-run,
-        unliftio
+        network-run
 
     if impl(ghc >=8)
         default-extensions: Strict StrictData

--- a/dnsext-utils/test/FastStreamSpec.hs
+++ b/dnsext-utils/test/FastStreamSpec.hs
@@ -3,11 +3,11 @@
 module FastStreamSpec where
 
 import Control.Concurrent
+import qualified Control.Exception as E
 import Data.ByteString ()
 import Data.IORef
 import Network.Run.TCP
 import Test.Hspec
-import qualified UnliftIO.Exception as E
 
 import DNS.TAP.FastStream
 


### PR DESCRIPTION
This PR removes `unliftio` as we have removed asynchronous exceptions.
`http2` and `quic` will eventually be asynchronous-exception-free.