### PR TITLE
Non-blocking recv for TCP and TLS

### DIFF
--- a/dnsext-do53/DNS/Do53/Internal.hs
+++ b/dnsext-do53/DNS/Do53/Internal.hs
@@ -2,8 +2,6 @@ module DNS.Do53.Internal (
     -- * IO types
     Recv,
     RecvN,
-    RecvMany,
-    RecvManyN,
     Send,
     SendMany,
 
@@ -17,10 +15,6 @@ module DNS.Do53.Internal (
     recvVC,
     encodeVCLength,
     decodeVCLength,
-
-    -- * Making recvMany
-    recvManyN,
-    recvManyNN,
 
     -- * Resolver
     Resolver,

--- a/dnsext-do53/DNS/Do53/Types.hs
+++ b/dnsext-do53/DNS/Do53/Types.hs
@@ -36,8 +36,6 @@ module DNS.Do53.Types (
     -- * IO
     Recv,
     RecvN,
-    RecvMany,
-    RecvManyN,
     Send,
     SendMany,
 )
@@ -305,10 +303,6 @@ rsso _ = return ()
 type Recv = IO ByteString
 
 type RecvN = Int -> IO ByteString
-
-type RecvMany = IO (Int, [ByteString])
-
-type RecvManyN = Int -> IO (Int, [ByteString])
 
 type Send = ByteString -> IO ()
 

--- a/dnsext-do53/dnsext-do53.cabal
+++ b/dnsext-do53/dnsext-do53.cabal
@@ -57,6 +57,7 @@ library
         mtl,
         network >= 3.2.3 && < 3.3,
         random >=1.2,
+        recv,
         stm,
         unix-time
 

--- a/dnsext-dox/DNS/DoX/QUIC.hs
+++ b/dnsext-dox/DNS/DoX/QUIC.hs
@@ -41,12 +41,12 @@ resolv conn ri@ResolveInfo{..} q qctl = do
         tx = BS.length qry
     sendVC (sendStreamMany strm) qry
     shutdownStream strm
-    (rx, bss) <- recvVC rinfoVCLimit $ recvStream strm
+    bs <- recvVC rinfoVCLimit $ recvStream strm 2048
     now <- getTime
-    case decodeChunks now bss of
+    case decodeAt now bs of
         Left e -> return $ Left e
         Right msg -> case checkRespM q ident msg of -- fixme
-            Nothing -> return $ Right $ Reply tag msg tx rx
+            Nothing -> return $ Right $ Reply tag msg tx $ BS.length bs
             Just err -> return $ Left err
   where
     getTime = ractionGetTime rinfoActions

--- a/dnsext-dox/dnsext-dox.cabal
+++ b/dnsext-dox/dnsext-dox.cabal
@@ -48,7 +48,6 @@ library
         iproute,
         network >= 3.2.2 && < 3.3,
         quic >= 0.2.1 && < 0.3,
-        recv >=0.1.0,
         serialise,
         tls >= 2.1
 

--- a/dnsext-iterative/DNS/Iterative/Server.hs
+++ b/dnsext-iterative/DNS/Iterative/Server.hs
@@ -56,11 +56,13 @@ module DNS.Iterative.Server (
     enableVcTimeout,
     addVcPending,
     delVcPending,
+    module DNS.Iterative.Server.NonBlocking,
 ) where
 
 import DNS.Iterative.Query.Env
 import DNS.Iterative.Server.HTTP2
 import DNS.Iterative.Server.HTTP3
+import DNS.Iterative.Server.NonBlocking
 import DNS.Iterative.Server.Pipeline
 import DNS.Iterative.Server.PrometheusHisto (getHistogramBucktes)
 import DNS.Iterative.Server.QUIC

--- a/dnsext-iterative/DNS/Iterative/Server.hs
+++ b/dnsext-iterative/DNS/Iterative/Server.hs
@@ -45,7 +45,7 @@ module DNS.Iterative.Server (
     initVcSession,
     mkInput,
     noPendingOp,
-    getRecvVC,
+    checkReceived,
     receiverVC,
     getSendVC,
     senderVC,

--- a/dnsext-iterative/DNS/Iterative/Server.hs
+++ b/dnsext-iterative/DNS/Iterative/Server.hs
@@ -35,7 +35,7 @@ module DNS.Iterative.Server (
     getStats,
 
     -- * Tests
-    Recv,
+    RecvPI,
     Send,
     VcTimer (..),
     VcSession (..),

--- a/dnsext-iterative/DNS/Iterative/Server/NonBlocking.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/NonBlocking.hs
@@ -28,7 +28,7 @@ data NBRecvR = EOF ByteString | NotEnough | NBytes ByteString
 type NBRecv = IO NBRecvR
 type NBRecvN = Int -> IO NBRecvR
 
-data State = E | S ByteString | M ([ByteString] -> [ByteString])
+type Buffer = [ByteString] -> [ByteString]
 
 makeNBRecvVC :: VCLimit -> Recv -> IO NBRecv
 makeNBRecvVC lim rcv = do
@@ -37,8 +37,8 @@ makeNBRecvVC lim rcv = do
     return $ nbRecvVC lim ref nbrecvN
 
 makeNBRecvN :: Recv -> ByteString -> IO NBRecvN
-makeNBRecvN rcv "" = nbRecvN rcv <$> newIORef (0, E)
-makeNBRecvN rcv bs0 = nbRecvN rcv <$> newIORef (len, S bs0)
+makeNBRecvN rcv "" = nbRecvN rcv <$> newIORef (0, id)
+makeNBRecvN rcv bs0 = nbRecvN rcv <$> newIORef (len, (bs0 :))
   where
     len = BS.length bs0
 
@@ -74,59 +74,36 @@ nbRecvVC lim ref nbrecvN = do
 
 nbRecvN
     :: Recv
-    -> IORef (Int, State)
+    -> IORef (Int, Buffer)
     -> NBRecvN
 nbRecvN rcv ref n = do
-    (len0, st) <- readIORef ref
+    (len0, build0) <- readIORef ref
     if
         | len0 == n -> do
-            writeIORef ref (0, E)
-            case st of
-                E -> return $ NBytes ""
-                S bs0 -> return $ NBytes bs0
-                M build0 -> return $ NBytes $ BS.concat $ build0 []
+            writeIORef ref (0, id)
+            return $ NBytes $ BS.concat $ build0 []
         | len0 > n -> do
-            case st of
-                E -> error "nbRecvN E"
-                S bs0 -> do
-                    let (ret, left) = BS.splitAt n bs0
-                    writeIORef ref (BS.length left, S left)
-                    return $ NBytes ret
-                M build0 -> do
-                    -- slow path
-                    let bs = BS.concat $ build0 []
-                        (ret, left) = BS.splitAt n bs
-                    writeIORef ref (BS.length left, S left)
-                    return $ NBytes ret
+            let bs = BS.concat $ build0 []
+                (ret, left) = BS.splitAt n bs
+            writeIORef ref (BS.length left, (left :))
+            return $ NBytes ret
         | otherwise -> do
             bs1 <- rcv
             if BS.null bs1
                 then do
-                    writeIORef ref (0, E)
-                    case st of
-                        E -> return $ EOF ""
-                        S bs -> return $ EOF bs
-                        M build -> return $ EOF $ BS.concat $ build []
+                    writeIORef ref (0, id)
+                    return $ EOF $ BS.concat $ build0 []
                 else do
                     let len1 = BS.length bs1
                         len2 = len0 + len1
                     if
                         | len2 == n -> do
-                            writeIORef ref (0, E)
-                            case st of
-                                E -> return $ NBytes bs1
-                                S bs0 -> return $ NBytes (bs0 <> bs1)
-                                M build0 -> return $ NBytes $ BS.concat $ build0 [bs1]
+                            writeIORef ref (0, id)
+                            return $ NBytes $ BS.concat $ build0 [bs1]
                         | len2 > n -> do
                             let (bs3, left) = BS.splitAt (n - len0) bs1
-                            writeIORef ref (BS.length left, S left)
-                            case st of
-                                E -> return $ NBytes bs3
-                                S bs0 -> return $ NBytes (bs0 <> bs3)
-                                M build0 -> return $ NBytes $ BS.concat $ build0 [bs3]
+                            writeIORef ref (BS.length left, (left :))
+                            return $ NBytes $ BS.concat $ build0 [bs3]
                         | otherwise -> do
-                            case st of
-                                E -> writeIORef ref (len2, S bs1)
-                                S bs0 -> writeIORef ref (len2, M ((bs0 :) . (bs1 :)))
-                                M build0 -> writeIORef ref (len2, M (build0 . (bs1 :)))
+                            writeIORef ref (len2, build0 . (bs1 :))
                             return NotEnough

--- a/dnsext-iterative/DNS/Iterative/Server/NonBlocking.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/NonBlocking.hs
@@ -7,6 +7,9 @@ module DNS.Iterative.Server.NonBlocking (
     NBRecvN,
     NBRecvR (..),
     makeNBRecvVC,
+
+    -- * for testing
+    makeNBRecvN,
 )
 where
 

--- a/dnsext-iterative/DNS/Iterative/Server/NonBlocking.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/NonBlocking.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module DNS.Iterative.Server.NonBlocking (
+    -- * Non-blocking RecvN
+    NBRecv,
+    NBRecvN,
+    NBRecvR (..),
+    makeNBRecvVC,
+)
+where
+
+import qualified Control.Exception as E
+import Control.Monad (when)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.IORef
+
+import DNS.Do53.Internal
+import DNS.Types
+
+data NBRecvR = EOF ByteString | NotEnough | NBytes ByteString
+    deriving (Eq, Show)
+
+type NBRecv = IO NBRecvR
+type NBRecvN = Int -> IO NBRecvR
+
+data State = E | S ByteString | M ([ByteString] -> [ByteString])
+
+makeNBRecvVC :: VCLimit -> Recv -> IO NBRecv
+makeNBRecvVC lim rcv = do
+    ref <- newIORef Nothing
+    nbrecvN <- makeNBRecvN rcv ""
+    return $ nbRecvVC lim ref nbrecvN
+
+makeNBRecvN :: Recv -> ByteString -> IO NBRecvN
+makeNBRecvN rcv "" = nbRecvN rcv <$> newIORef (0, E)
+makeNBRecvN rcv bs0 = nbRecvN rcv <$> newIORef (len, S bs0)
+  where
+    len = BS.length bs0
+
+nbRecvVC :: VCLimit -> IORef (Maybe Int) -> NBRecvN -> NBRecv
+nbRecvVC lim ref nbrecvN = do
+    mi <- readIORef ref
+    case mi of
+        Nothing -> do
+            x <- nbrecvN 2
+            case x of
+                NBytes bs -> do
+                    let len = decodeVCLength bs
+                    when (fromIntegral len > lim) $
+                        E.throwIO $
+                            DecodeError $
+                                "length is over the limit: should be len <= lim, but (len: "
+                                    ++ show len
+                                    ++ ") > (lim: "
+                                    ++ show lim
+                                    ++ ") "
+                    writeIORef ref $ Just len
+                    return NotEnough
+                _ -> return x
+        Just len -> nbrecvN len
+
+nbRecvN
+    :: Recv
+    -> IORef (Int, State)
+    -> NBRecvN
+nbRecvN rcv ref n = do
+    (len0, st) <- readIORef ref
+    if
+        | len0 == n -> do
+            writeIORef ref (0, E)
+            case st of
+                E -> return $ NBytes ""
+                S bs0 -> return $ NBytes bs0
+                M build0 -> return $ NBytes $ BS.concat $ build0 []
+        | len0 > n -> do
+            case st of
+                E -> error "nbRecvN E"
+                S bs0 -> do
+                    let (ret, left) = BS.splitAt n bs0
+                    writeIORef ref (BS.length left, S left)
+                    return $ NBytes ret
+                M build0 -> do
+                    -- slow path
+                    let bs = BS.concat $ build0 []
+                        (ret, left) = BS.splitAt n bs
+                    writeIORef ref (BS.length left, S left)
+                    return $ NBytes ret
+        | otherwise -> do
+            bs1 <- rcv
+            if BS.null bs1
+                then do
+                    writeIORef ref (0, E)
+                    case st of
+                        E -> return $ EOF ""
+                        S bs -> return $ EOF bs
+                        M build -> return $ EOF $ BS.concat $ build []
+                else do
+                    let len1 = BS.length bs1
+                        len2 = len0 + len1
+                    if
+                        | len2 == n -> do
+                            writeIORef ref (0, E)
+                            case st of
+                                E -> return $ NBytes bs1
+                                S bs0 -> return $ NBytes (bs0 <> bs1)
+                                M build0 -> return $ NBytes $ BS.concat $ build0 [bs1]
+                        | len2 > n -> do
+                            let (bs3, left) = BS.splitAt (n - len0) bs1
+                            writeIORef ref (BS.length left, S left)
+                            case st of
+                                E -> return $ NBytes bs3
+                                S bs0 -> return $ NBytes (bs0 <> bs3)
+                                M build0 -> return $ NBytes $ BS.concat $ build0 [bs3]
+                        | otherwise -> do
+                            case st of
+                                E -> writeIORef ref (len2, S bs1)
+                                S bs0 -> writeIORef ref (len2, M ((bs0 :) . (bs1 :)))
+                                M build0 -> writeIORef ref (len2, M (build0 . (bs1 :)))
+                            return NotEnough

--- a/dnsext-iterative/DNS/Iterative/Server/Pipeline.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/Pipeline.hs
@@ -19,7 +19,7 @@ module DNS.Iterative.Server.Pipeline (
     enableVcTimeout,
     addVcPending,
     delVcPending,
-    getRecvVC,
+    checkReceived,
     receiverVC,
     getSendVC,
     senderVC,
@@ -218,12 +218,10 @@ type MkInput = ByteString -> PeerInfo -> VcPendingOp -> EpochTimeUsec -> Input B
 mkInput :: SockAddr -> (ToSender -> IO ()) -> SocketProtocol -> MkInput
 mkInput mysa toSender proto bs peerInfo pendingOp = Input bs pendingOp mysa peerInfo proto toSender
 
-getRecvVC :: Int -> VcTimer -> RecvPI -> RecvPI
-getRecvVC slsize timer recv = do
-    bp@(bs, _) <- recv
+checkReceived :: Int -> VcTimer -> ByteString -> IO ()
+checkReceived slsize timer bs = do
     let sz = BS.length bs
     when (sz > slsize || sz == 0) $ resetVcTimer timer
-    return bp
 
 receiverVC
     :: String

--- a/dnsext-iterative/DNS/Iterative/Server/TCP.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/TCP.hs
@@ -50,8 +50,9 @@ tcpServer VcServerConfig{..} env toCacher s = do
         let peerInfo = PeerInfoVC peersa
         (vcSess, toSender, fromX) <- initVcSession (waitReadSocketSTM sock)
         withVcTimer tmicro (atomically $ enableVcTimeout $ vcTimeout_ vcSess) $ \vcTimer -> do
-            let recv = getRecvVC vc_slowloris_size vcTimer $ do
+            let recv = do
                     bs <- DNS.recvVC maxSize $ DNS.recvTCP sock
+                    checkReceived vc_slowloris_size vcTimer bs
                     incStatsTCP53 peersa (stats_ env)
                     return (bs, peerInfo)
                 send = getSendVC vcTimer $ \bs _ -> DNS.sendVC (DNS.sendTCP sock) bs

--- a/dnsext-iterative/DNS/Iterative/Server/TCP.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/TCP.hs
@@ -54,9 +54,9 @@ tcpServer VcServerConfig{..} env toCacher s = do
                     bs <- DNS.recvVC maxSize $ DNS.recvTCP sock
                     checkReceived vc_slowloris_size vcTimer bs
                     incStatsTCP53 peersa (stats_ env)
-                    return (bs, peerInfo)
+                    return bs
                 send = getSendVC vcTimer $ \bs _ -> DNS.sendVC (DNS.sendTCP sock) bs
-                receiver = receiverVC "tcp-recv" env vcSess recv toCacher $ mkInput mysa toSender TCP
+                receiver = receiverVCnonBlocking "tcp-recv" env vcSess peerInfo recv toCacher $ mkInput mysa toSender TCP
                 sender = senderVC "tcp-send" env vcSess send fromX
             TStat.concurrently_ "tcp-send" sender "tcp-recv" receiver
         logLn env Log.DEBUG $ "tcp-srv: close: " ++ show peersa

--- a/dnsext-iterative/DNS/Iterative/Server/TCP.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/TCP.hs
@@ -23,6 +23,7 @@ import Network.Socket (getPeerName, getSocketName, waitReadSocketSTM)
 
 -- this package
 import DNS.Iterative.Internal (Env (..))
+import DNS.Iterative.Server.NonBlocking
 import DNS.Iterative.Server.Pipeline
 import DNS.Iterative.Server.Types
 import DNS.Iterative.Stats (incStatsTCP53, sessionStatsTCP53)
@@ -50,13 +51,12 @@ tcpServer VcServerConfig{..} env toCacher s = do
         let peerInfo = PeerInfoVC peersa
         (vcSess, toSender, fromX) <- initVcSession (waitReadSocketSTM sock)
         withVcTimer tmicro (atomically $ enableVcTimeout $ vcTimeout_ vcSess) $ \vcTimer -> do
-            let recv = do
-                    bs <- DNS.recvVC maxSize $ DNS.recvTCP sock
+            recv <- makeNBRecvVC maxSize $ DNS.recvTCP sock
+            let onRecv bs = do
                     checkReceived vc_slowloris_size vcTimer bs
                     incStatsTCP53 peersa (stats_ env)
-                    return bs
-                send = getSendVC vcTimer $ \bs _ -> DNS.sendVC (DNS.sendTCP sock) bs
-                receiver = receiverVCnonBlocking "tcp-recv" env vcSess peerInfo recv toCacher $ mkInput mysa toSender TCP
+            let send = getSendVC vcTimer $ \bs _ -> DNS.sendVC (DNS.sendTCP sock) bs
+                receiver = receiverVCnonBlocking "tcp-recv" env vcSess peerInfo recv onRecv toCacher $ mkInput mysa toSender TCP
                 sender = senderVC "tcp-send" env vcSess send fromX
             TStat.concurrently_ "tcp-send" sender "tcp-recv" receiver
         logLn env Log.DEBUG $ "tcp-srv: close: " ++ show peersa

--- a/dnsext-iterative/DNS/Iterative/Server/TLS.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/TLS.hs
@@ -56,9 +56,9 @@ tlsServer VcServerConfig{..} env toCacher s = do
                     bs <- DNS.recvVC maxSize $ H2.recv backend
                     checkReceived vc_slowloris_size vcTimer bs
                     incStatsDoT peersa (stats_ env)
-                    return (bs, peerInfo)
+                    return bs
                 send = getSendVC vcTimer $ \bs _ -> DNS.sendVC (H2.sendMany backend) bs
-                receiver = receiverVC "tls-recv" env vcSess recv toCacher $ mkInput mysa toSender DOT
+                receiver = receiverVCnonBlocking "tls-recv" env vcSess peerInfo recv toCacher $ mkInput mysa toSender DOT
                 sender = senderVC "tls-send" env vcSess send fromX
             TStat.concurrently_ "tls-send" sender "tls-recv" receiver
         logLn env Log.DEBUG $ "tls-srv: close: " ++ show peersa

--- a/dnsext-iterative/DNS/Iterative/Server/TLS.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/TLS.hs
@@ -52,8 +52,9 @@ tlsServer VcServerConfig{..} env toCacher s = do
         logLn env Log.DEBUG $ "tls-srv: accept: " ++ show peersa
         (vcSess, toSender, fromX) <- initVcSession (pure $ pure ())
         withVcTimer tmicro (atomically $ enableVcTimeout $ vcTimeout_ vcSess) $ \vcTimer -> do
-            let recv = getRecvVC vc_slowloris_size vcTimer $ do
+            let recv = do
                     bs <- DNS.recvVC maxSize $ H2.recv backend
+                    checkReceived vc_slowloris_size vcTimer bs
                     incStatsDoT peersa (stats_ env)
                     return (bs, peerInfo)
                 send = getSendVC vcTimer $ \bs _ -> DNS.sendVC (H2.sendMany backend) bs

--- a/dnsext-iterative/dnsext-iterative.cabal
+++ b/dnsext-iterative/dnsext-iterative.cabal
@@ -78,7 +78,6 @@ library
         psqueues,
         quic >= 0.2.1 && < 0.3,
         random,
-        recv,
         stm,
         time-manager,
         tls >= 2.1,

--- a/dnsext-iterative/dnsext-iterative.cabal
+++ b/dnsext-iterative/dnsext-iterative.cabal
@@ -42,14 +42,15 @@ library
         DNS.Iterative.RootTrustAnchors
         DNS.Iterative.Server.HTTP2
         DNS.Iterative.Server.HTTP3
+        DNS.Iterative.Server.NonBlocking
         DNS.Iterative.Server.Pipeline
+        DNS.Iterative.Server.PrometheusHisto
         DNS.Iterative.Server.QUIC
         DNS.Iterative.Server.TCP
         DNS.Iterative.Server.TLS
         DNS.Iterative.Server.Types
         DNS.Iterative.Server.UDP
         DNS.Iterative.Server.WorkerStats
-        DNS.Iterative.Server.PrometheusHisto
         DNS.Iterative.Stats
 
     default-language: Haskell2010

--- a/dnsext-iterative/dnsext-iterative.cabal
+++ b/dnsext-iterative/dnsext-iterative.cabal
@@ -115,9 +115,10 @@ test-suite spec
     build-tool-depends: hspec-discover:hspec-discover
     hs-source-dirs:     test
     other-modules:
+                        NonBlockingSpec
                         QuerySpec
-                        SessionSpec
                         SessionPropSpec
+                        SessionSpec
     default-language:   Haskell2010
     ghc-options:        -Wall -threaded
     build-depends:

--- a/dnsext-iterative/test/NonBlockingSpec.hs
+++ b/dnsext-iterative/test/NonBlockingSpec.hs
@@ -78,7 +78,7 @@ testNBRecvN
     :: ByteString -> [ByteString] -> Int -> [NBRecvR] -> IO ()
 testNBRecvN ini xs n ress = do
     rcv <- makeRecv xs
-    nbRecvN <- makeNBRecvN rcv ini
+    nbRecvN <- makeNBRecvN ini rcv
     mapM_ (nbRecvN n `shouldReturn`) ress
 
 makeRecv :: [ByteString] -> IO (IO ByteString)

--- a/dnsext-iterative/test/NonBlockingSpec.hs
+++ b/dnsext-iterative/test/NonBlockingSpec.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module NonBlockingSpec where
+
+import Data.ByteString (ByteString)
+import Data.IORef
+import Test.Hspec (Spec, describe, hspec, it, shouldReturn)
+
+import DNS.Iterative.Server
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+    describe "NBRecvN" $ do
+        it "should work well" $ do
+            testNBRecvN "" [] 5 [EOF "", EOF "", EOF ""]
+            testNBRecvN "" ["abcde"] 5 [NBytes "abcde", EOF ""]
+            testNBRecvN
+                ""
+                ["abcdefgh"]
+                5
+                [NBytes "abcde", EOF "fgh", EOF ""]
+
+            testNBRecvN
+                ""
+                ["ab", "cdefgh"]
+                5
+                [NotEnough, NBytes "abcde", EOF "fgh", EOF ""]
+            testNBRecvN
+                ""
+                ["a", "b", "c", "d", "e", "f", "g", "h"]
+                5
+                [ NotEnough
+                , NotEnough
+                , NotEnough
+                , NotEnough
+                , NBytes "abcde"
+                , NotEnough
+                , NotEnough
+                , NotEnough
+                , EOF "fgh"
+                , EOF ""
+                ]
+
+            testNBRecvN "xyz" [] 2 [NBytes "xy", EOF "z", EOF "", EOF ""]
+            testNBRecvN "xyz" [] 5 [EOF "xyz", EOF "", EOF ""]
+            testNBRecvN "xyz" ["ab"] 5 [NBytes "xyzab", EOF "", EOF ""]
+            testNBRecvN
+                "xyz"
+                ["abcdefgh"]
+                5
+                [NBytes "xyzab", NBytes "cdefg", EOF "h", EOF ""]
+
+            testNBRecvN
+                "xyz"
+                ["ab", "cdefgh"]
+                5
+                [NBytes "xyzab", NBytes "cdefg", EOF "h", EOF ""]
+            testNBRecvN
+                "xyz"
+                ["a", "b", "c", "d", "e", "f", "g", "h"]
+                5
+                [ NotEnough
+                , NBytes "xyzab"
+                , NotEnough
+                , NotEnough
+                , NotEnough
+                , NotEnough
+                , NBytes "cdefg"
+                , NotEnough
+                , EOF "h"
+                , EOF ""
+                ]
+
+testNBRecvN
+    :: ByteString -> [ByteString] -> Int -> [NBRecvR] -> IO ()
+testNBRecvN ini xs n ress = do
+    rcv <- makeRecv xs
+    nbRecvN <- makeNBRecvN rcv ini
+    mapM_ (nbRecvN n `shouldReturn`) ress
+
+makeRecv :: [ByteString] -> IO (IO ByteString)
+makeRecv xs0 = do
+    ref <- newIORef xs0
+    return $ rcv ref
+  where
+    rcv ref = do
+        xss <- readIORef ref
+        case xss of
+            [] -> return ""
+            x : xs -> do
+                writeIORef ref xs
+                return x

--- a/dnsext-iterative/test/SessionSpec.hs
+++ b/dnsext-iterative/test/SessionSpec.hs
@@ -123,7 +123,10 @@ runSession factor recv0 waitRead tmicro = withVc waitRead tmicro $ \(vcSess, toS
     (getResult, send0) <- getSend
     debug <- maybe False ((== "1") . take 1) <$> lookupEnv "VCTEST_DEBUG"
     let myaddr = SockAddrInet 53 0x0100007f
-        recv = getRecvVC 0 timer recv0
+        recv = do
+            bp@(bs, _) <- recv0
+            checkReceived 0 timer bs
+            return bp
         send = getSendVC timer send0
         receiver = receiverVC "test-recv" env vcSess recv toCacher (mkInput myaddr toSender UDP)
         sender = senderVC "test-send" env vcSess send fromX

--- a/dnsext-iterative/test/SessionSpec.hs
+++ b/dnsext-iterative/test/SessionSpec.hs
@@ -34,7 +34,8 @@ spec = do
     sessionSpec
 
 withVc
-    :: IO (STM ()) -> Int
+    :: IO (STM ())
+    -> Int
     -> ((VcSession, ToSender -> IO (), IO FromX) -> VcTimer -> IO a)
     -> IO a
 withVc getWaitIn micro action = do
@@ -134,6 +135,7 @@ runSession factor recv0 waitRead tmicro = withVc waitRead tmicro $ \(vcSess, toS
     fstate <- TStat.concurrently "test-send" sender "test-recv" receiver
     result <- sort <$> getResult
     pure (fstate, result)
+
 {- FOUMOLU_ENABLE -}
 
 dump :: VcSession -> IO ()
@@ -152,9 +154,10 @@ getToCacher factor = do
             inputToSender $ Output inputQuery inputPendingOp inputPeerInfo
     _ <- replicateM 4 (forkIO bodyLoop)
     pure (atomically . writeTQueue mq)
+
 {- FOUMOLU_ENABLE -}
 
-getRecv :: [ByteString] -> IO Recv
+getRecv :: [ByteString] -> IO RecvPI
 getRecv ws = do
     ref <- newIORef ws
     pure $ rstep ref

--- a/dnsext-types/DNS/Types/Decode.hs
+++ b/dnsext-types/DNS/Types/Decode.hs
@@ -1,24 +1,14 @@
 -- | DNS message decoders.
 --
--- When in doubt, use the 'decodeAt' or 'decodeManyAt' functions, which
--- correctly handle /circle-arithmetic/ DNS timestamps, e.g., in @RRSIG@
--- resource records.  The 'decode', and 'decodeMany' functions are only
--- appropriate in pure contexts when the current time is not available, and
--- @RRSIG@ records are not expected or desired.
---
--- The 'decodeMany' and 'decodeManyAt' functions decode a buffer holding one or
--- more messages, each preceded by 16-bit length in network byte order.  This
--- encoding is generally only appropriate for DNS TCP, and because TCP does not
--- preserve message boundaries, the decode is prepared to return a trailing
--- message fragment to be completed and retried when more input arrives from
--- network.
+-- When in doubt, use the 'decodeAt' function, which correctly handle
+-- /circle-arithmetic/ DNS timestamps, e.g., in @RRSIG@ resource
+-- records.  The 'decode' functionsare only appropriate in pure
+-- contexts when the current time is not available, and @RRSIG@
+-- records are not expected or desired.
 module DNS.Types.Decode (
     -- * Decoding a single DNS message
     decodeAt,
     decode,
-
-    -- * Generic decoder
-    decodeChunks,
 
     -- * Decoders for parts
     decodeDNSFlags,
@@ -70,14 +60,6 @@ decode
     -> Either DNSError DNSMessage
     -- ^ decoded message or error
 decode bs = runParser getDNSMessage bs
-
-----------------------------------------------------------------
-
-decodeChunks
-    :: EpochTime
-    -> [ByteString]
-    -> Either DNSError DNSMessage
-decodeChunks t bss = decodeAt t $ BS.concat bss
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
- Removing `RecvMany` to simplify the `recv` stuff
- Defining and using non-block recv for TCP and TLS