### PR TITLE
TCP nonblocking receiver does not work when data arrives in bulk

### DIFF
--- a/dnsext-iterative/DNS/Iterative/Server/NonBlocking.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/NonBlocking.hs
@@ -81,13 +81,13 @@ nbRecvN rcv ref n = do
         | len0 == n -> do
             writeIORef ref (0, id)
             return $ NBytes $ BS.concat $ build0 []
-        | len0 > n -> do
+        | len0 > n -> do  {- only wrong, over-sized case -}
             let bs = BS.concat $ build0 []
                 (ret, left) = BS.splitAt n bs
             writeIORef ref (BS.length left, (left :))
             return $ NBytes ret
         | otherwise -> do
-            bs1 <- rcv 2048 {- dummy arg before fix -}
+            bs1 <- rcv (n - len0)
             if BS.null bs1
                 then do
                     writeIORef ref (0, id)
@@ -99,7 +99,7 @@ nbRecvN rcv ref n = do
                         | len2 == n -> do
                             writeIORef ref (0, id)
                             return $ NBytes $ BS.concat $ build0 [bs1]
-                        | len2 > n -> do
+                        | len2 > n -> do  {- only wrong, over-sized case -}
                             let (bs3, left) = BS.splitAt (n - len0) bs1
                             writeIORef ref (BS.length left, (left :))
                             return $ NBytes $ BS.concat $ build0 [bs3]

--- a/dnsext-iterative/DNS/Iterative/Server/TCP.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/TCP.hs
@@ -51,7 +51,7 @@ tcpServer VcServerConfig{..} env toCacher s = do
         let peerInfo = PeerInfoVC peersa
         (vcSess, toSender, fromX) <- initVcSession (waitReadSocketSTM sock)
         withVcTimer tmicro (atomically $ enableVcTimeout $ vcTimeout_ vcSess) $ \vcTimer -> do
-            recv <- makeNBRecvVC maxSize $ DNS.recvTCP sock
+            recv <- makeNBRecvVCNoSize maxSize $ DNS.recvTCP sock
             let onRecv bs = do
                     checkReceived vc_slowloris_size vcTimer bs
                     incStatsTCP53 peersa (stats_ env)

--- a/dnsext-iterative/DNS/Iterative/Server/TCP.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/TCP.hs
@@ -20,6 +20,7 @@ import qualified DNS.ThreadStats as TStat
 -- other packages
 import Network.Run.TCP
 import Network.Socket (getPeerName, getSocketName, waitReadSocketSTM)
+import qualified Network.Socket.ByteString as Network
 
 -- this package
 import DNS.Iterative.Internal (Env (..))
@@ -51,7 +52,7 @@ tcpServer VcServerConfig{..} env toCacher s = do
         let peerInfo = PeerInfoVC peersa
         (vcSess, toSender, fromX) <- initVcSession (waitReadSocketSTM sock)
         withVcTimer tmicro (atomically $ enableVcTimeout $ vcTimeout_ vcSess) $ \vcTimer -> do
-            recv <- makeNBRecvVCNoSize maxSize $ DNS.recvTCP sock
+            recv <- makeNBRecvVC maxSize $ Network.recv sock
             let onRecv bs = do
                     checkReceived vc_slowloris_size vcTimer bs
                     incStatsTCP53 peersa (stats_ env)

--- a/dnsext-iterative/DNS/Iterative/Server/TLS.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/TLS.hs
@@ -53,7 +53,7 @@ tlsServer VcServerConfig{..} env toCacher s = do
         logLn env Log.DEBUG $ "tls-srv: accept: " ++ show peersa
         (vcSess, toSender, fromX) <- initVcSession (pure $ pure ())
         withVcTimer tmicro (atomically $ enableVcTimeout $ vcTimeout_ vcSess) $ \vcTimer -> do
-            recv <- makeNBRecvVC maxSize $ H2.recv backend
+            recv <- makeNBRecvVCNoSize maxSize $ H2.recv backend
             let onRecv bs = do
                     checkReceived vc_slowloris_size vcTimer bs
                     incStatsDoT peersa (stats_ env)

--- a/dnsext-iterative/dnsext-iterative.cabal
+++ b/dnsext-iterative/dnsext-iterative.cabal
@@ -133,7 +133,8 @@ test-suite spec
         dnsext-types,
         dnsext-utils,
         QuickCheck,
-        hspec
+        hspec,
+        hspec-expectations
 
     if (os(windows) && impl(ghc >=9.0))
         ghc-options: -with-rtsopts=--io-manager=native

--- a/dnsext-iterative/test/NonBlockingSpec.hs
+++ b/dnsext-iterative/test/NonBlockingSpec.hs
@@ -78,7 +78,7 @@ testNBRecvN
     :: ByteString -> [ByteString] -> Int -> [NBRecvR] -> IO ()
 testNBRecvN ini xs n ress = do
     rcv <- makeRecv xs
-    nbRecvN <- makeNBRecvN ini rcv
+    nbRecvN <- makeNBRecvN ini (\_ -> rcv)
     mapM_ (nbRecvN n `shouldReturn`) ress
 
 makeRecv :: [ByteString] -> IO (IO ByteString)

--- a/dnsext-iterative/test/NonBlockingSpec.hs
+++ b/dnsext-iterative/test/NonBlockingSpec.hs
@@ -3,14 +3,18 @@
 module NonBlockingSpec where
 
 import Data.ByteString (ByteString)
+import Data.Functor
+import Data.String
 import Data.IORef
 import Test.Hspec (Spec, describe, hspec, it, shouldReturn)
+import Test.Hspec.Expectations.Contrib (annotate)
 
 import DNS.Iterative.Server
 
 main :: IO ()
 main = hspec spec
 
+{- FOURMOLU_DISABLE -}
 spec :: Spec
 spec = do
     describe "NBRecvN" $ do
@@ -73,6 +77,39 @@ spec = do
                 , EOF "h"
                 , EOF ""
                 ]
+    specReadable
+
+specReadable :: Spec
+specReadable = do
+    describe "NBRecvN readable" $ do
+        it "eof" $ do
+            testNBRecvNReadable
+                [ (Close, True, [ (3, EOF "", False) ])
+                ]
+        it "not-enough" $ do
+            testNBRecvNReadable
+                [ (Bytes "abc", True, [ (5, NotEnough, False) ])
+                , (Close      , True, [])
+                ]
+        it "n-bytes - just" $ do
+            testNBRecvNReadable
+                [ (Bytes "abc", True, [ (3, NBytes "abc", False) ])
+                , (Close      , True, [ (3, EOF ""      , False) ])
+                ]
+        it "n-bytes - over" $ do
+            testNBRecvNReadable
+                [ (Bytes "abcdef", True, [ (3, NBytes "abc", True) ])
+                , (Close         , True, [ (3, NBytes "def", True)
+                                         , (3, EOF ""      , False) ])
+                ]
+        it "like VC dns message" $ do
+            testNBRecvNReadable
+                [ (Bytes ("\x00\x07" <> "abcdefg"), True, [ (2, NBytes "\x00\x07", True)
+                                                          , (7, NBytes "abcdefg" , False)
+                                                          ])
+                , (Close                          , True, [ (2, EOF ""          , False) ])
+                ]
+{- FOURMOLU_ENABLE -}
 
 testNBRecvN
     :: ByteString -> [ByteString] -> Int -> [NBRecvR] -> IO ()
@@ -93,3 +130,81 @@ makeRecv xs0 = do
             x : xs -> do
                 writeIORef ref xs
                 return x
+
+---
+
+testNBRecvNReadable
+    :: [(InEvent, Bool, [(Int, NBRecvR, Bool)])] -> IO ()
+testNBRecvNReadable xs = do
+    (readable, pushEv, rcv) <- makeSizedRecv
+    nbrecvN <- makeNBRecvN "" rcv
+    readable `shouldReturn` False
+    let check i j (sz, exnbr, exrd) = do
+            let ix = show i ++ ": " ++ show j ++ ": "
+            annotate (ix ++ "nbrecv result")        $ nbrecvN sz `shouldReturn` exnbr
+            annotate (ix ++ "readable after recv")  $ readable `shouldReturn` exrd
+        action i (ev, exrd0, ys) = do
+            pushEv ev
+            annotate (show i ++ ": readable after event") $ readable `shouldReturn` exrd0
+            sequence_ $ zipWith (check i) [(1::Int)..] ys
+    sequence_ $ zipWith action [(1::Int)..] xs
+
+data InEvent
+    = Bytes String
+    | Close
+    deriving Show
+
+data InState'
+    = Arrived String
+    | EndOfInput String
+    | NoArrived
+    deriving Show
+
+type InState = IORef (Maybe InState')
+
+{- FOURMOLU_DISABLE -}
+readable' :: Maybe InState' -> Bool
+readable' (Just (Arrived {}))     = True
+readable' (Just  NoArrived)       = False
+readable' (Just (EndOfInput {}))  = True
+readable'  Nothing                = False
+
+arrive :: IORef (Maybe InState') -> InEvent -> IO ()
+arrive is e0 = do
+    m <- readIORef is
+    arrive' m e0
+  where
+    arrive' (Just (Arrived s0))     (Bytes s)   = writeIORef is $ Just $ Arrived (s0 ++ s)
+    arrive' (Just (Arrived s0))      Close      = writeIORef is $ Just $ EndOfInput s0
+    arrive' (Just  NoArrived)       (Bytes "")  = writeIORef is $ Just   NoArrived
+    arrive' (Just  NoArrived)       (Bytes s)   = writeIORef is $ Just $ Arrived s
+    arrive' (Just  NoArrived)        Close      = writeIORef is $ Just $ EndOfInput ""
+    arrive' (Just (EndOfInput _))    e          = fail $ "wrong input state, input-event after eof: " ++ show e
+    arrive'  Nothing                 e          = fail $ "wrong input state, input-event after closed: " ++ show e
+
+consume :: IORef (Maybe InState') -> Int -> IO ByteString
+consume is sz = do
+    consume' =<< readIORef is
+  where
+    consume'  Nothing                = fail $ "cannot consume. after closed"
+    consume' (Just NoArrived)        = fail $ "cannot consume. no-avail data, blocked"
+    consume' (Just (EndOfInput ""))  = writeIORef is  Nothing $> ""
+    consume' (Just (EndOfInput s0))  = writeIORef is (Just next) $> fromString hd
+      where
+        next
+            | null tl    = EndOfInput ""
+            | otherwise  = EndOfInput tl
+        (hd, tl) = splitAt sz s0
+    consume' (Just (Arrived s0))     = writeIORef is (Just next) $> fromString hd
+      where
+        next
+            | null tl    = NoArrived
+            | otherwise  = Arrived tl
+        (hd, tl) = splitAt sz s0
+{- FOURMOLU_ENABLE -}
+
+makeSizedRecv :: IO (IO Bool, InEvent -> IO (), Int -> IO ByteString)
+makeSizedRecv = do
+    inSt <- newIORef $ Just NoArrived
+    let readable = readable' <$> readIORef inSt
+    return (readable, arrive inSt, consume inSt)


### PR DESCRIPTION
testing with custom config

```
udp-port: 1053
tcp-port: 1053
```

dig client and dug client got timeout for DNS over TCP53

```
 % dig @127.0.0.1 www.iij.ad.jp A +tcp -p 1053
;; communications error to 127.0.0.1#1053: timed out
;; communications error to 127.0.0.1#1053: timed out
;; communications error to 127.0.0.1#1053: timed out

; <<>> DiG 9.20.2-1-Debian <<>> @127.0.0.1 www.iij.ad.jp A +tcp -p 1053
; (1 server found)
;; global options: +cmd
;; no servers could be reached
```

```
 % dug @127.0.0.1 www.iij.ad.jp A -d tcp -p 1053
TimeoutExpired
;; 3sec 4usec
```

degraded since non-blocking recv things https://github.com/kazu-yamamoto/dnsext/compare/8f0d4ee6..28dbb978
