### PR TITLE
dnsext does NOT preserve multi-string TXT RDATA

### DIFF
--- a/dnsext-types/DNS/Types.hs
+++ b/dnsext-types/DNS/Types.hs
@@ -99,6 +99,7 @@ module DNS.Types (
     -- *** TXT RR
     RD_TXT,
     rd_txt,
+    rd_txt_n,
     txt_opaque,
 
     -- *** RP RR

--- a/dnsext-types/test/RoundTripSpec.hs
+++ b/dnsext-types/test/RoundTripSpec.hs
@@ -128,7 +128,7 @@ mkRData dom typ =
         A -> rd_a <$> genIPv4
         AAAA -> rd_aaaa <$> genIPv6
         NS -> pure $ rd_ns dom
-        TXT -> rd_txt <$> genTextString
+        TXT -> rd_txt_n <$> genTextStrings
         MX -> rd_mx <$> genWord16 <*> genDomain
         CNAME -> pure $ rd_cname dom
         SOA ->
@@ -145,8 +145,11 @@ mkRData dom typ =
         TLSA -> rd_tlsa <$> genWord8 <*> genWord8 <*> genWord8 <*> genOpaque
         _ -> pure . rd_txt $ fromString ("Unhandled type " <> show typ)
   where
+    genTextStrings = do
+        chunks <- elements [1..5] -- chunk=0 is not llegal one or more <character-sstring>s, RFC 1035, RFC 6763
+        replicateM chunks genTextString
     genTextString = do
-        len <- elements [0, 1, 63, 255, 256, 511, 512, 1023, 1024]
+        len <- elements [0, 1, 63, 127, 255]
         Opaque.fromShortByteString . Short.pack <$> replicateM len genWord8
 
 genIPv4 :: Gen IPv4


### PR DESCRIPTION
```
 % dig @adam.ns.cloudflare.com txt.reasonings.cc. TXT
...
;; ANSWER SECTION:
txt.reasonings.cc.	300	IN	TXT	"multi field" "txt data"
...
```

```
 % dug @adam.ns.cloudflare.com txt.reasonings.cc. TXT
...
;; ANSWER SECTION:
txt.reasonings.cc.	300(5 mins)	IN	TXT	"multi fieldtxt data"
...
```

This issue is also present in the `dns` library, which is the original of `dnsext`, and was introduced in the following commits.
docoder: https://github.com/kazu-yamamoto/dns/commit/a91e0dddda38025efd2eaf4d6b19d78c1e9d0d2d#diff-55f50d982a955bd252a818f837f05d872f4780ac3e0837adbf55acdba3160e84R252-R262
encoder: https://github.com/kazu-yamamoto/dns/commit/0690fc2396e4c64e2e5fa8eb3cd311e4d4ade74e#diff-0ca28911fb8ef3f4fae25f6472c75ee8edbb50adac1703e30488cc1b4599ff00R180-R185
