### PR TITLE
apply keylog to quic

### DIFF
--- a/dnsext-iterative/DNS/Iterative/Server/HTTP3.hs
+++ b/dnsext-iterative/DNS/Iterative/Server/HTTP3.hs
@@ -38,7 +38,7 @@ http3Servers VcServerConfig{..} env toCacher ss = do
   where
     sbracket = sessionStatsDoH3 (stats_ env)
     incQuery inet6 = incStatsDoH3 inet6 (stats_ env)
-    sconf = getServerConfig vc_credentials vc_session_manager "h3" (vc_idle_timeout * 1000)
+    sconf = getServerConfig vc_credentials vc_session_manager "h3" (vc_idle_timeout * 1000) env
     conf mgr =
         H3.Config
             { confHooks = H3.defaultHooks


### PR DESCRIPTION
For `BOWLINE_SSLKEYLOGFILE` for `doq` and `h3` transport.