### PR TITLE
Using Crypto.PubKey.RSA.PKCS15

### DIFF
--- a/dnsext-dnssec/DNS/SEC/Verify/RSA.hs
+++ b/dnsext-dnssec/DNS/SEC/Verify/RSA.hs
@@ -14,18 +14,16 @@ where
 
 -- crypton
 
-import Crypto.Hash (HashAlgorithm, hashWith)
+import Crypto.Hash (HashAlgorithm)
 import Crypto.Hash.Algorithms (SHA1 (..), SHA256 (..), SHA512 (..))
 import Crypto.Number.Serialize (i2osp, os2ip)
 import Crypto.PubKey.RSA (PublicKey (..))
-import Crypto.PubKey.RSA.Prim (ep)
+import Crypto.PubKey.RSA.PKCS15 (HashAlgorithmASN1, verify)
 import DNS.SEC.Types (PubKey (..))
 import DNS.SEC.Verify.Types
 import DNS.Types
 import qualified DNS.Types.Opaque as Opaque
-import qualified Data.ByteArray as BA
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as B8
 import Data.Maybe (fromJust)
 
 {- Verify RRSIG with DNSKEY using RSA/SHA-x
@@ -34,11 +32,11 @@ import Data.Maybe (fromJust)
  -}
 
 rsaSHA1, rsaSHA256, rsaSHA512 :: RRSIGImpl
-rsaSHA1 = rsaSHAHelper sha1
-rsaSHA256 = rsaSHAHelper sha256
-rsaSHA512 = rsaSHAHelper sha512
+rsaSHA1 = rsaSHAHelper SHA1
+rsaSHA256 = rsaSHAHelper SHA256
+rsaSHA512 = rsaSHAHelper SHA512
 
-rsaSHAHelper :: HashAlgorithm hash => (hash, ByteString) -> RRSIGImpl
+rsaSHAHelper :: (HashAlgorithm hash, HashAlgorithmASN1 hash) => hash -> RRSIGImpl
 rsaSHAHelper alg =
     RRSIGImpl
         { rrsigIGetKey = rsaDecodePubKey
@@ -109,50 +107,11 @@ rsaDecodeSignature :: Opaque -> Either String Signature
 rsaDecodeSignature = Right
 
 rsaVerify
-    :: HashAlgorithm hash
-    => (hash, ByteString)
+    :: (HashAlgorithm hash, HashAlgorithmASN1 hash)
+    => hash
     -> PublicKey
     -> Signature
     -> ByteString
     -> Either String Bool
-rsaVerify (alg, pkcs1) pubkey sig msg = do
-    decoded <- unpadPKCS1Prefix $ ep pubkey $ Opaque.toByteString sig
-    return $ hashWith' msg == decoded
-  where
-    unpadPKCS1Prefix :: ByteString -> Either String ByteString
-    unpadPKCS1Prefix s0 = do
-        s1 <- stripP "\x00\x01" s0
-        let s2 = B8.dropWhile (== '\xff') s1
-        s3 <- stripP "\x00" s2
-        stripP pkcs1 s3
-      where
-        stripP prefix =
-            maybe (Left $ "RSASHA.rsaVerify: expected prefix: " ++ show prefix) Right
-                . B8.stripPrefix prefix
-    hashWith' :: ByteString -> ByteString
-    hashWith' = BA.convert . hashWith alg
-
-{-
--- PKCS for RSA/SHA
--- https://datatracker.ietf.org/doc/html/rfc8017#section-9.2
-
-     SHA-1:       (0x)30 21 30 09 06 05 2b 0e 03 02 1a 05 00 04 14 || H.
-     SHA-224:     (0x)30 2d 30 0d 06 09 60 86 48 01 65 03 04 02 04 05 00 04 1c || H.
-     SHA-256:     (0x)30 31 30 0d 06 09 60 86 48 01 65 03 04 02 01 05 00 04 20 || H.
-     SHA-384:     (0x)30 41 30 0d 06 09 60 86 48 01 65 03 04 02 02 05 00 04 30 || H.
-     SHA-512:     (0x)30 51 30 0d 06 09 60 86 48 01 65 03 04 02 03 05 00 04 40 || H.
- -}
-sha1 :: (SHA1, ByteString)
-sha1 = (SHA1, "\x30\x21\x30\x09\x06\x05\x2b\x0e\x03\x02\x1a\x05\x00\x04\x14")
-
-sha256 :: (SHA256, ByteString)
-sha256 =
-    ( SHA256
-    , "\x30\x31\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x01\x05\x00\x04\x20"
-    )
-
-sha512 :: (SHA512, ByteString)
-sha512 =
-    ( SHA512
-    , "\x30\x51\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x03\x05\x00\x04\x40"
-    )
+rsaVerify alg pubkey sig msg =
+    Right $ verify (Just alg) pubkey msg $ Opaque.toByteString sig

--- a/dnsext-dnssec/DNS/SEC/Verify/RSA.hs
+++ b/dnsext-dnssec/DNS/SEC/Verify/RSA.hs
@@ -17,8 +17,9 @@ where
 import Crypto.Hash (HashAlgorithm)
 import Crypto.Hash.Algorithms (SHA1 (..), SHA256 (..), SHA512 (..))
 import Crypto.Number.Serialize (i2osp, os2ip)
-import Crypto.PubKey.RSA (PublicKey (..))
-import Crypto.PubKey.RSA.PKCS15 (HashAlgorithmASN1, verify)
+import Crypto.PubKey.RSA (PrivateKey (..), PublicKey (..))
+import Crypto.PubKey.RSA.PKCS15 (HashAlgorithmASN1, signSafer, verify)
+import Crypto.Random.Types (MonadRandom)
 import DNS.SEC.Types (PubKey (..))
 import DNS.SEC.Verify.Types
 import DNS.Types
@@ -115,3 +116,15 @@ rsaVerify
     -> Either String Bool
 rsaVerify alg pubkey sig msg =
     Right $ verify (Just alg) pubkey msg $ Opaque.toByteString sig
+
+unsafeRsaSign
+    :: (HashAlgorithm hash, HashAlgorithmASN1 hash, MonadRandom m)
+    => hash
+    -> PrivateKey
+    -> ByteString
+    -> m Signature
+unsafeRsaSign alg prikey msg = do
+    ex <- signSafer (Just alg) prikey msg
+    case ex of
+        Left _ -> return $ Opaque.fromByteString ""
+        Right s -> return $ Opaque.fromByteString s


### PR DESCRIPTION
Side channel attacks to PKCS 1.5 and the workaround is described in https://www.ietf.org/archive/id/draft-irtf-cfrg-rsa-guidance-00.html.

*Verify* is safe because it does not use private keys. @khibino's implementation and that of `Crypto.PubKey.RSA.PKCS15` are almost the same.

*Sign* must use blinder to prevent the side channel attacks. We can just use `Crypto.PubKey.RSA.PKCS15.signSafer`. I don't find any reasons to implement it by ourself again.

Also, I don't see any reasons to *not* use `Crypto.PubKey.RSA.PKCS15.verify`. This PR is just use `Crypto.PubKey.RSA.PKCS15` for both sign and verify.