### PR TITLE
Making the DS parser support multiple lines.

### DIFF
--- a/dnsext-types/DNS/Types.hs
+++ b/dnsext-types/DNS/Types.hs
@@ -91,6 +91,12 @@ module DNS.Types (
     rd_ptr,
     ptr_domain,
 
+    -- *** HINFO RR
+    RD_HINFO,
+    rd_hinfo,
+    hinfo_cpu,
+    hinfo_os,
+
     -- *** MX RR
     RD_MX,
     rd_mx,
@@ -194,6 +200,7 @@ module DNS.Types (
         SOA,
         NULL,
         PTR,
+        HINFO,
         MX,
         TXT,
         RP,

--- a/dnsext-types/DNS/Types/RData.hs
+++ b/dnsext-types/DNS/Types/RData.hs
@@ -25,6 +25,9 @@ import DNS.Types.Serial
 import DNS.Types.Type
 import DNS.Wire
 
+import qualified Data.ByteString.Char8 as C8
+import qualified Data.ByteString.Short as Short
+
 ---------------------------------------------------------------
 
 class (Typeable a, Eq a, Show a) => ResourceData a where
@@ -242,6 +245,41 @@ instance Show RD_NULL where
 
 rd_null :: Opaque -> RData
 rd_null = toRData . RD_NULL
+
+----------------------------------------------------------------
+
+-- Host information (RFC1035)
+data RD_HINFO = RD_HINFO
+    { hinfo_cpu :: ShortByteString
+    , hinfo_os :: ShortByteString
+    }
+    deriving (Eq, Ord)
+
+instance ResourceData RD_HINFO where
+    resourceDataType _ = HINFO
+    resourceDataSize (RD_HINFO cpu os) = Short.length cpu + Short.length os + 2
+    putResourceData _ (RD_HINFO cpu os) = \wbuf _ -> do
+        putLenShortByteString wbuf cpu
+        putLenShortByteString wbuf os
+
+get_hinfo :: Int -> Parser RD_HINFO
+get_hinfo _ rbuf _ = RD_HINFO <$> getCharString <*> getCharString
+  where
+    getCharString = getInt8 rbuf >>= getNShortByteString rbuf
+
+instance Show RD_HINFO where
+    show (RD_HINFO cpu os) = toString cpu ++ " " ++ toString os
+      where
+        toString = C8.unpack . Short.fromShort
+
+-- | Smart constructor.
+rd_hinfo :: ShortByteString -> ShortByteString -> RData
+rd_hinfo cpu os =
+    toRData $
+        RD_HINFO
+            { hinfo_cpu = cpu
+            , hinfo_os = os
+            }
 
 ----------------------------------------------------------------
 

--- a/dnsext-types/DNS/Types/Type.hs
+++ b/dnsext-types/DNS/Types/Type.hs
@@ -9,6 +9,7 @@ module DNS.Types.Type (
         SOA,
         NULL,
         PTR,
+        HINFO,
         MX,
         TXT,
         RP,
@@ -84,6 +85,10 @@ pattern NULL = TYPE 10
 pattern PTR :: TYPE
 pattern PTR = TYPE 12
 
+-- | Host information
+pattern HINFO :: TYPE
+pattern HINFO = TYPE 13
+
 -- | Mail exchange
 pattern MX :: TYPE
 pattern MX = TYPE 15
@@ -148,6 +153,7 @@ typeAndNames =
     , (SOA,   "SOA")
     , (NULL,  "NULL")
     , (PTR,   "PTR")
+    , (HINFO, "HINFO")
     , (MX,    "MX")
     , (TXT,   "TXT")
     , (RP,    "RP")

--- a/dnsext-utils/DNS/ZoneFile/Parser.hs
+++ b/dnsext-utils/DNS/ZoneFile/Parser.hs
@@ -183,6 +183,9 @@ rdataAAAA = rd_aaaa <$> ipv6
 rdataPTR :: Parser RData
 rdataPTR = rd_ptr <$> domain
 
+rdataHINFO :: Parser RData
+rdataHINFO = rd_hinfo <$> cstring <*> (blank *> cstring)
+
 rdataTXT :: MonadParser Token s m => m RData
 rdataTXT = rd_txt_n . txts <$> ((:) <$> nbstring <*> many (blank *> nbstring))
   where
@@ -269,6 +272,7 @@ rrTyRData mk =
        , (MX     , rdataMX     )
        , (CNAME  , rdataCNAME  )
        , (SOA    , rdataSOA    )
+       , (HINFO  , rdataHINFO  )
        ] ++
        rdatasDNSSEC ++
        rdatasSVCB domain)

--- a/dnsext-utils/DNS/ZoneFile/ParserDNSSEC.hs
+++ b/dnsext-utils/DNS/ZoneFile/ParserDNSSEC.hs
@@ -4,6 +4,7 @@ module DNS.ZoneFile.ParserDNSSEC where
 
 -- GHC packages
 import Control.Applicative
+import Data.ByteString (ByteString)
 import Data.ByteString.Short (fromShort)
 import Data.Word
 
@@ -46,12 +47,16 @@ rdataDNSKEY = do
     keyflags = toDNSKEYflags <$> readCString "dnskey.flags"
     proto = readCString "dnskey.proto"
     handleB64 = either (raise . ("Parser.rdataDNSKEY: fromBase64: " ++)) pure
-    part = fromShort . cs_cs <$> lstring
-    parts = (mconcat <$>) $ (:) <$> part <*> many (blank *> part)
     keyB64 = handleB64 . Opaque.fromBase64 =<< parts
 {- FOURMOLU_ENABLE -}
 
 -----
+
+part :: MonadParser Token s m => m ByteString
+part = fromShort . cs_cs <$> lstring
+
+parts :: MonadParser Token s m => m ByteString
+parts = (mconcat <$>) $ (:) <$> part <*> many (blank *> part)
 
 keytag :: MonadParser Token s m => m Word16
 keytag = readCString "keytag"
@@ -63,6 +68,6 @@ digestalg :: MonadParser Token s m => m DigestAlg
 digestalg = toDigestAlg <$> readCString "digestalg"
 
 digest :: MonadParser Token s m => m Opaque
-digest = handleB16 . Opaque.fromBase16 . fromShort =<< cstring
+digest = handleB16 . Opaque.fromBase16 =<< parts
   where
     handleB16 = either (raise . ("Parser.digest: fromBase16: " ++)) pure


### PR DESCRIPTION
Supporting the example of RFC 4034:

```
dskey.example.com. 86400 IN DS 60485 5 1 ( 2BB183AF5F22588179A53B0A
                                              98631FAD1A292118 )
```